### PR TITLE
Update with upstream features

### DIFF
--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -1,6 +1,6 @@
 import { Meteor } from "meteor/meteor";
-import { useTracker } from "meteor/react-meteor-data";
-import React, { useCallback, useMemo } from "react";
+import { useSubscribe, useTracker } from "meteor/react-meteor-data";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { Modal, ModalBody, ModalFooter } from "react-bootstrap";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
@@ -109,9 +109,22 @@ const HuntMemberError = React.memo(
 
 const HuntApp = React.memo(() => {
   const huntId = useParams<"huntId">().huntId!;
+  const puzzleId = useParams<"puzzleId">().puzzleId;
+
 
   const huntLoading = useTypedSubscribe(huntForHuntApp, { huntId });
   const loading = huntLoading();
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      const status = document.visibilityState === 'visible' ? 'online' : 'away';
+      Meteor.subscribe('userStatus.inc', huntId, 'status', status);
+    };
+    handleVisibilityChange();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [huntId]);
 
   const hunt = useTracker(() => Hunts.findOneAllowingDeleted(huntId), [huntId]);
   const { member, canUndestroy, canJoin, mustAcceptTerms } = useTracker(() => {

--- a/imports/client/components/HuntEditPage.tsx
+++ b/imports/client/components/HuntEditPage.tsx
@@ -297,7 +297,6 @@ const HuntEditPage = () => {
         default:
           return;
       }
-      console.log(newRoles);
       setDefaultRoles(newRoles);
     },
     [],

--- a/imports/client/components/HuntEditPage.tsx
+++ b/imports/client/components/HuntEditPage.tsx
@@ -34,6 +34,7 @@ import { useBreadcrumb } from "../hooks/breadcrumb";
 import useTypedSubscribe from "../hooks/useTypedSubscribe";
 import ActionButtonRow from "./ActionButtonRow";
 import Markdown from "./Markdown";
+import Select, { ActionMeta } from "react-select";
 
 enum SubmitState {
   IDLE = "idle",
@@ -41,6 +42,12 @@ enum SubmitState {
   SUCCESS = "success",
   FAILED = "failed",
 }
+
+const huntRolesList = [
+  "operator",
+]
+
+type RoleSelectOption = {value: string, label: string};
 
 const splitLists = function (lists: string): string[] {
   const strippedLists = lists.trim();
@@ -219,6 +226,11 @@ const HuntEditPage = () => {
   const [mailingLists, setMailingLists] = useState<string>(
     hunt?.mailingLists.join(", ") ?? "",
   );
+
+  const [defaultRoles, setDefaultRoles] = useState<string[]>(
+    hunt?.defaultRoles ?? [],
+  );
+
   const [signupMessage, setSignupMessage] = useState<string>(
     hunt?.signupMessage ?? "",
   );
@@ -266,6 +278,30 @@ const HuntEditPage = () => {
   >((e) => {
     setMailingLists(e.currentTarget.value);
   }, []);
+
+  const onDefaultRolesChanged = useCallback(
+    (
+      value: readonly RoleSelectOption[],
+      action: ActionMeta<RoleSelectOption>,
+    ) => {
+      let newRoles = [];
+      switch (action.action) {
+        case "clear":
+        case "deselect-option":
+        case "remove-value":
+        case "create-option":
+        case "pop-value":
+        case "select-option":
+              newRoles = value.map((v) => v.value);
+              break;
+        default:
+          return;
+      }
+      console.log(newRoles);
+      setDefaultRoles(newRoles);
+    },
+    [],
+  );
 
   const onSignupMessageChanged = useCallback<
     NonNullable<FormControlProps["onChange"]>
@@ -374,6 +410,7 @@ const HuntEditPage = () => {
         firehoseDiscordChannel,
         memberDiscordRole,
         isArchived,
+        defaultRoles,
       };
 
       if (huntId) {
@@ -397,6 +434,7 @@ const HuntEditPage = () => {
       firehoseDiscordChannel,
       memberDiscordRole,
       onFormCallback,
+      defaultRoles,
     ],
   );
 
@@ -467,6 +505,24 @@ const HuntEditPage = () => {
           </Col>
         </FormGroup>
 
+        <FormGroup as={Row} className="mb-3">
+          <FormLabel column xs={3} htmlFor="hunt-form-default-roles">
+            Default roles
+          </FormLabel>
+          <Col xs={9}>
+          <Select
+            id="hunt-form-default-roles"
+            isMulti
+            options={huntRolesList.map((r) => {return {label: r, value: r}})}
+            value={defaultRoles.map((r) => {return {label: r, value: r}})}
+            onChange={onDefaultRolesChanged}
+            disabled={disableForm}
+          />
+            <FormText>
+              Users joining this hunt will be automatically assigned these roles.
+            </FormText>
+          </Col>
+        </FormGroup>
         <FormGroup as={Row} className="mb-3">
           <FormLabel column xs={3} htmlFor="hunt-form-open-signups">
             Open invites

--- a/imports/client/components/HuntNav.tsx
+++ b/imports/client/components/HuntNav.tsx
@@ -6,6 +6,7 @@ import { faMap } from "@fortawesome/free-solid-svg-icons/faMap";
 import { faReceipt } from "@fortawesome/free-solid-svg-icons/faReceipt";
 import { faTags } from "@fortawesome/free-solid-svg-icons/faTags";
 import { faUsers } from "@fortawesome/free-solid-svg-icons/faUsers";
+import { faEllipsisH } from "@fortawesome/free-solid-svg-icons/faEllipsisH";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 import { Nav } from "react-bootstrap";
@@ -204,6 +205,14 @@ const HuntNav = () => {
           </StyledPuzzleListLinkAnchor>
         )}
         {huntLink}
+
+        <StyledPuzzleListLinkAnchor
+          to={`/hunts/${huntId}/more`}
+          title="More"
+        >
+          <MenuIcon icon={faEllipsisH} />
+          <StyledPuzzleListLinkLabel>More</StyledPuzzleListLinkLabel>
+        </StyledPuzzleListLinkAnchor>
       </JRLinkList>
     );
   } else {

--- a/imports/client/components/MoreAppPage.tsx
+++ b/imports/client/components/MoreAppPage.tsx
@@ -1,33 +1,12 @@
-import { useFind, useTracker } from "meteor/react-meteor-data";
-import { faEraser } from "@fortawesome/free-solid-svg-icons/faEraser";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
   useMemo,
-  useRef,
-  useState,
 } from "react";
-import Button from "react-bootstrap/Button";
-import type { FormControlProps } from "react-bootstrap/FormControl";
-import FormControl from "react-bootstrap/FormControl";
-import FormGroup from "react-bootstrap/FormGroup";
-import InputGroup from "react-bootstrap/InputGroup";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import { shortCalendarTimeFormat } from "../../lib/calendarTimeFormat";
-import { indexedById } from "../../lib/listUtils";
 import type { ChatMessageType } from "../../lib/models/ChatMessages";
-import ChatMessages from "../../lib/models/ChatMessages";
-import Puzzles from "../../lib/models/Puzzles";
 import type { PuzzleType } from "../../lib/models/Puzzles";
 import nodeIsMention from "../../lib/nodeIsMention";
-import chatMessagesForFirehose from "../../lib/publications/chatMessagesForFirehose";
-import { useBreadcrumb } from "../hooks/breadcrumb";
-import useSubscribeDisplayNames from "../hooks/useSubscribeDisplayNames";
-import useTypedSubscribe from "../hooks/useTypedSubscribe";
-import indexedDisplayNames from "../indexedDisplayNames";
 import FixedLayout from "./styling/FixedLayout";
 
 const FirehosePageLayout = styled.div`
@@ -119,12 +98,11 @@ const MessagesPane = styled.div`
 
 const MoreAppPage = () => {
   const huntId = useParams<"huntId">().huntId!;
+  const jr_hostname = window.location.hostname;
   const bookmarklet = useMemo(() => {
     const code = `
       (function() {
-        const title = encodeURIComponent(document.title);
-        const url = encodeURIComponent(window.location.href);
-        window.location.href = "${window.location.hostname}/hunts/${huntId}/puzzles#title=" + title + "&url=" + url;
+        window.location.href = "https://${jr_hostname}/hunts/${huntId}/puzzles#title=" + document.title + "&url=" + window.location.href;
       })();
     `;
     return `javascript:${encodeURIComponent(code)}`;

--- a/imports/client/components/MoreAppPage.tsx
+++ b/imports/client/components/MoreAppPage.tsx
@@ -8,6 +8,7 @@ import type { ChatMessageType } from "../../lib/models/ChatMessages";
 import type { PuzzleType } from "../../lib/models/Puzzles";
 import nodeIsMention from "../../lib/nodeIsMention";
 import FixedLayout from "./styling/FixedLayout";
+import { Alert } from "react-bootstrap";
 
 const FirehosePageLayout = styled.div`
   padding: 8px 15px;
@@ -123,7 +124,9 @@ const MoreAppPage = () => {
 
         <p>Drag this bookmarklet to your bookmarks bar!</p>
 
-        <a href={bookmarklet}>Add to Jolly Roger</a> {/* Bookmarklet link */}
+        <p><a href={bookmarklet}>Add to Jolly Roger</a></p>
+
+        <Alert variant="warning">Note: You'll need a new/different version of this for each hunt.</Alert>
 
       </FirehosePageLayout>
     </FixedLayout>

--- a/imports/client/components/MoreAppPage.tsx
+++ b/imports/client/components/MoreAppPage.tsx
@@ -9,6 +9,7 @@ import type { PuzzleType } from "../../lib/models/Puzzles";
 import nodeIsMention from "../../lib/nodeIsMention";
 import FixedLayout from "./styling/FixedLayout";
 import { Alert } from "react-bootstrap";
+import { useBreadcrumb } from "../hooks/breadcrumb";
 
 const FirehosePageLayout = styled.div`
   padding: 8px 15px;
@@ -99,6 +100,9 @@ const MessagesPane = styled.div`
 
 const MoreAppPage = () => {
   const huntId = useParams<"huntId">().huntId!;
+
+  useBreadcrumb({ title: "More", path: `/hunts/${huntId}/more` });
+
   const jr_hostname = window.location.hostname;
   const bookmarklet = useMemo(() => {
     const code = `

--- a/imports/client/components/MoreAppPage.tsx
+++ b/imports/client/components/MoreAppPage.tsx
@@ -1,0 +1,155 @@
+import { useFind, useTracker } from "meteor/react-meteor-data";
+import { faEraser } from "@fortawesome/free-solid-svg-icons/faEraser";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Button from "react-bootstrap/Button";
+import type { FormControlProps } from "react-bootstrap/FormControl";
+import FormControl from "react-bootstrap/FormControl";
+import FormGroup from "react-bootstrap/FormGroup";
+import InputGroup from "react-bootstrap/InputGroup";
+import { useParams, useSearchParams } from "react-router-dom";
+import styled from "styled-components";
+import { shortCalendarTimeFormat } from "../../lib/calendarTimeFormat";
+import { indexedById } from "../../lib/listUtils";
+import type { ChatMessageType } from "../../lib/models/ChatMessages";
+import ChatMessages from "../../lib/models/ChatMessages";
+import Puzzles from "../../lib/models/Puzzles";
+import type { PuzzleType } from "../../lib/models/Puzzles";
+import nodeIsMention from "../../lib/nodeIsMention";
+import chatMessagesForFirehose from "../../lib/publications/chatMessagesForFirehose";
+import { useBreadcrumb } from "../hooks/breadcrumb";
+import useSubscribeDisplayNames from "../hooks/useSubscribeDisplayNames";
+import useTypedSubscribe from "../hooks/useTypedSubscribe";
+import indexedDisplayNames from "../indexedDisplayNames";
+import FixedLayout from "./styling/FixedLayout";
+
+const FirehosePageLayout = styled.div`
+  padding: 8px 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  height: 100%;
+
+  > * {
+    width: 100%;
+  }
+`;
+
+interface MessageProps {
+  msg: ChatMessageType;
+  displayNames: Map<string, string>;
+  puzzle: PuzzleType | undefined;
+}
+
+const PreWrapSpan = styled.span`
+  display: block;
+  white-space: pre-wrap;
+  padding-left: 1em;
+`;
+
+function asFlatString(
+  chatMessage: ChatMessageType,
+  displayNames: Map<string, string>,
+): string {
+  return chatMessage.content.children
+    .map((child) => {
+      if (nodeIsMention(child)) {
+        return ` @${displayNames.get(child.userId) ?? "???"} `;
+      } else {
+        return child.text;
+      }
+    })
+    .join(" ");
+}
+
+const Message = React.memo(({ msg, displayNames, puzzle }: MessageProps) => {
+  const ts = shortCalendarTimeFormat(msg.timestamp);
+  const displayName = msg.sender
+    ? (displayNames.get(msg.sender) ?? "???")
+    : "jolly-roger";
+  const messageText = asFlatString(msg, displayNames);
+  const hasNewline = messageText.includes("\n");
+  return (
+    <div>
+      <span>
+        [{ts}] [
+        {puzzle !== undefined ? (
+          <>
+            <span>{`${puzzle.deleted ? "deleted: " : ""}`}</span>
+            <a
+              href={`/hunts/${msg.hunt}/puzzles/${msg.puzzle}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {puzzle.title}
+            </a>
+          </>
+        ) : (
+          <span>deleted: no data</span>
+        )}
+        {"] "}
+        {displayName}
+        {": "}
+      </span>
+      {hasNewline ? (
+        <PreWrapSpan>{messageText}</PreWrapSpan>
+      ) : (
+        <span>{messageText}</span>
+      )}
+    </div>
+  );
+});
+
+const MessagesPane = styled.div`
+  overflow-y: scroll;
+  flex: 1;
+
+  &.live {
+    border-bottom: 1px solid black;
+  }
+`;
+
+const MoreAppPage = () => {
+  const huntId = useParams<"huntId">().huntId!;
+  const bookmarklet = useMemo(() => {
+    const code = `
+      (function() {
+        const title = encodeURIComponent(document.title);
+        const url = encodeURIComponent(window.location.href);
+        window.location.href = "${window.location.hostname}/hunts/${huntId}/puzzles#title=" + title + "&url=" + url;
+      })();
+    `;
+    return `javascript:${encodeURIComponent(code)}`;
+  }, [huntId]);
+
+
+  return (
+    <FixedLayout>
+      <FirehosePageLayout>
+        <h1>More resources</h1>
+        <h2>Bookmarklet</h2>
+
+        <p>This bookmarklet will:</p>
+        <ul>
+          <li>If the puzzle exists in Jolly Roger, take you to the puzzle page, or</li>
+          <li>If the puzzle doesn't yet exist in Jolly Roger, take you to the list of puzzles with the title and URL prepopulated.</li>
+        </ul>
+
+        <p>Drag this bookmarklet to your bookmarks bar!</p>
+
+        <a href={bookmarklet}>Add to Jolly Roger</a> {/* Bookmarklet link */}
+
+      </FirehosePageLayout>
+    </FixedLayout>
+  );
+};
+
+export default MoreAppPage;

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -1082,7 +1082,7 @@ const NotificationCenter = () => {
 
   return (
     <StyledToastContainer position="bottom-end" className="p-3 position-fixed">
-      {messages}
+      {messages.reverse()}
     </StyledToastContainer>
   );
 };

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -57,6 +57,9 @@ import Markdown from "./Markdown";
 import PuzzleAnswer from "./PuzzleAnswer";
 import SpinnerTimer from "./SpinnerTimer";
 import { GuessConfidence, GuessDirection } from "./guessDetails";
+import PuzzleNotifications, { PuzzleNotificationType } from "../../lib/models/PuzzleNotifications";
+import dismissPuzzleNotification from "../../methods/dismissPuzzleNotification";
+import puzzleNotificationsForSelf from "../../lib/publications/puzzleNotificationsForSelf";
 
 // How long to keep showing guess notifications after actioning.
 // Note that this cannot usefully exceed the linger period implemented by the
@@ -574,6 +577,42 @@ const ProfileMissingMessage = ({ onDismiss }: { onDismiss: () => void }) => {
   );
 };
 
+const PuzzleNotificationMessage = ({
+  pn,
+  hunt,
+  puzzle,
+  content,
+}: {
+  pn: PuzzleNotificationType;
+  hunt: HuntType;
+  puzzle: PuzzleType;
+  content: string;
+}) => {
+  const id = pn._id;
+  const dismiss = useCallback(
+    () => dismissPuzzleNotification.call({ puzzleNotificationId: id }),
+    [id]
+  );
+
+  return (
+    <Toast onClose={dismiss}>
+      <Toast.Header>
+        <strong className="me-auto">
+          <Link to={`/hunts/${hunt._id}/puzzles/${puzzle._id}`}>{puzzle.title}</Link>
+        </strong>
+      <StyledNotificationTimestamp>
+        {calendarTimeFormat(pn.createdAt)}
+      </StyledNotificationTimestamp>
+      </Toast.Header>
+      <Toast.Body>
+        <div>
+          {content}
+        </div>
+      </Toast.Body>
+    </Toast>
+  )
+}
+
 const ChatNotificationMessage = ({
   cn,
   hunt,
@@ -746,6 +785,9 @@ const NotificationCenter = () => {
   const bookmarkNotificationsLoading = useTypedSubscribe(
     bookmarkNotificationsForSelf,
   );
+  const puzzleNotificationsLoading = useTypedSubscribe(
+    puzzleNotificationsForSelf,
+  );
 
   const disableDingwords = useTracker(() => Flags.active("disable.dingwords"));
   const chatNotificationsLoading = useSubscribe(
@@ -756,7 +798,8 @@ const NotificationCenter = () => {
     pendingGuessesLoading() ||
     pendingAnnouncementsLoading() ||
     bookmarkNotificationsLoading() ||
-    chatNotificationsLoading();
+    chatNotificationsLoading() ||
+    puzzleNotificationsLoading();
 
   const discordEnabledOnServer = useTracker(
     () =>
@@ -839,6 +882,13 @@ const NotificationCenter = () => {
             { sort: { createdAt: 1 } },
           ).fetch(),
     [loading],
+  );
+  const puzzleNotifications = useTracker(
+    () =>
+      loading || disableDingwords
+        ? []
+        : PuzzleNotifications.find({}, { sort: { timestamp: 1 } }).fetch(),
+    [loading, disableDingwords],
   );
   const chatNotifications = useTracker(
     () =>
@@ -1011,6 +1061,21 @@ const NotificationCenter = () => {
         bn={bn}
         hunt={hunt}
         puzzle={puzzle}
+      />,
+    );
+  });
+
+  puzzleNotifications.forEach((pn) => {
+    const hunt = hunts.get(pn.hunt);
+    const puzzle = puzzles.get(pn.puzzle);
+    if (!hunt || !puzzle) return;
+    messages.push(
+      <PuzzleNotificationMessage
+        key={pn._id}
+        pn={pn}
+        hunt={hunt}
+        puzzle={puzzle}
+        content={pn.content}
       />,
     );
   });

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -378,11 +378,25 @@ const UserStatusBadge = React.memo(({
   huntId,
   huntPuzzles,
 }: {
-  statusObj: Record<string, any>;
+  statusObj: Record<string, any> | null;
   huntId: string | undefined;
   huntPuzzles: PuzzleType[];
 }) => {
-  const fiveMinutesAgo = new Date(Date.now() - 1 * 60 * 1000);
+
+  if (!statusObj) {
+    return <StatusDiv>
+      <OverlayTrigger placement="top" overlay={<Tooltip>Offline (never seen)</Tooltip>}>
+          <ButtonGroup size="sm">
+              <Button
+              variant='outline-secondary'
+              >
+                Offline
+              </Button>
+          </ButtonGroup>
+      </OverlayTrigger>
+    </StatusDiv>;
+  }
+  const fiveMinutesAgo = new Date(Date.now() - 2 * 60 * 1000);
   const lastSeen = statusObj.status.at;
   const lastPuzzle = statusObj.puzzleStatus.at;
   const lastStatusRecently = lastSeen >= fiveMinutesAgo;
@@ -402,24 +416,22 @@ const UserStatusBadge = React.memo(({
     {puzzleName}</strong>
     { puzzleStatusString !== 'Online' ? (<span> <RelativeTime
     date={lastPuzzle}
-    terse
     minimumUnit="second"
     maxElements={1}
-  /> ago</span>) : null } </span>;
+  /></span>) : null } </span>;
   const tooltip = <span> {statusString}
   {
-    statusString !== 'Online' ? (
+    userStatus !== 'online' ? (
       <span>, last seen: {shortCalendarTimeFormat(lastSeen)}&nbsp;(<RelativeTime
         date={lastSeen}
-        terse
         minimumUnit="second"
         maxElements={1}
-      />&nbsp;ago)</span>
+      />)</span>
     ) : null
   }
   {
     puzzleStatusString !== 'Online' && lastPuzzle ? (
-      ', last active on puzzle:' + shortCalendarTimeFormat(lastPuzzle)
+      ', last active on puzzle: ' + shortCalendarTimeFormat(lastPuzzle)
     ) : lastPuzzle ? ', currently active on puzzle' : null
   }
   </span>;
@@ -776,13 +788,11 @@ const ProfileList = ({
               }>
                 {name}
                 </Link>
-                {userStatus && (
-                  <UserStatusBadge
-                  statusObj={userStatus}
-                  huntId={huntId}
-                  huntPuzzles={huntPuzzles}
-                  />
-                )}
+                <UserStatusBadge
+                statusObj={userStatus}
+                huntId={huntId}
+                huntPuzzles={huntPuzzles}
+                />
                 {hunt && canMakeOperator && (
                   <OperatorControls hunt={hunt} user={user} />
                 )}

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -391,7 +391,7 @@ const UserStatusBadge = React.memo(({
   if (!statusObj) {
     // we should display users as offline if we don't have data on them
     return <StatusDiv>
-      <OverlayTrigger placement="top" overlay={<Tooltip>Offline<br/>(not seen in last four days)</Tooltip>}>
+      <OverlayTrigger placement="top" overlay={<Tooltip>Offline</Tooltip>}>
           <ButtonGroup size="sm">
               <Button
               variant='outline-secondary'

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -406,32 +406,33 @@ const UserStatusBadge = React.memo(({
   const [lastSeen, setLastSeen] = useState<Date | null>(statusObj?.status?.at || null);
   const [lastPuzzle, setLastPuzzle] = useState<Date | null>(statusObj?.puzzleStatus?.at || null);
   const [timeNow, setTimeNow] = useState<Date | null>(new Date() || null);
+  const [puzzleStatusString, setPuzzleStatusString] = useState<string | null>( null );
   const statusDebounceThreshold = new Date(Date.now() - 2 * 60 * 1000);
   const relativeDebounceThreshold = new Date(Date.now() - 10 * 1000);
 
   useEffect(() => {
     const intervalId = setInterval(() => {
-      setLastSeen(statusObj?.status?.at || null);  // Update state every second
+      setLastSeen(statusObj?.status?.at || null);
       setLastPuzzle(statusObj?.puzzleStatus?.at || null);
       setTimeNow(new Date());
-    }, 1000); // Update every 1000ms (1 second)
+    }, puzzleStatusString === 'Online' ? 1000 : 60 * 1000);
 
     return () => clearInterval(intervalId);
   }, [statusObj]);
 
-  const lastStatusRecently = lastSeen && lastSeen >= statusDebounceThreshold;
-  const lastPuzzleRecently = lastPuzzle && lastPuzzle >= statusDebounceThreshold;
-  const puzzleCountdownDebounce = lastPuzzle && lastPuzzle >= relativeDebounceThreshold;
-  const lastSeenRecently = lastStatusRecently || lastPuzzleRecently;
 
   const statusDisplay = useMemo(() => {
+    const lastStatusRecently = lastSeen && lastSeen >= statusDebounceThreshold;
+    const lastPuzzleRecently = lastPuzzle && lastPuzzle >= statusDebounceThreshold;
+    const puzzleCountdownDebounce = lastPuzzle && lastPuzzle >= relativeDebounceThreshold;
+    const lastSeenRecently = lastStatusRecently || lastPuzzleRecently;
     const userStatus = statusObj?.status?.status;
     const puzzleStatus = statusObj?.puzzleStatus?.status;
     const puzzleId = statusObj?.puzzleStatus?.puzzle;
     const puzzleName = puzzleId ? huntPuzzles[puzzleId] : null;
 
     const statusString = (userStatus === 'offline' && !lastSeenRecently) ? 'Offline' : (userStatus === 'away' && !lastSeenRecently) ? 'Away' : 'Online';
-    const puzzleStatusString = (puzzleStatus === 'offline' && !lastPuzzleRecently) ? 'Offline' : (puzzleStatus === 'away' && !lastPuzzleRecently) ? 'Away' : 'Online';
+    setPuzzleStatusString((puzzleStatus === 'offline' && !lastPuzzleRecently) ? 'Offline' : (puzzleStatus === 'away' && !lastPuzzleRecently) ? 'Away' : 'Online');
     const puzzleLabel =
       <span><strong><FontAwesomeIcon icon={faPuzzlePiece} fixedWidth />&nbsp;
       {puzzleName}</strong>
@@ -483,7 +484,7 @@ const UserStatusBadge = React.memo(({
       </StatusDiv>
     );
   }, [
-    statusObj, lastSeenRecently, lastPuzzleRecently, lastSeen, lastPuzzle, huntPuzzles, timeNow,
+    statusObj, lastSeen, lastPuzzle, huntPuzzles, timeNow,
   ]);
 
   return statusDisplay;

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -407,6 +407,7 @@ const UserStatusBadge = React.memo(({
   const [lastPuzzle, setLastPuzzle] = useState<Date | null>(statusObj?.puzzleStatus?.at || null);
   const [timeNow, setTimeNow] = useState<Date | null>(new Date() || null);
   const statusDebounceThreshold = new Date(Date.now() - 2 * 60 * 1000);
+  const relativeDebounceThreshold = new Date(Date.now() - 10 * 1000);
 
   useEffect(() => {
     const intervalId = setInterval(() => {
@@ -420,6 +421,7 @@ const UserStatusBadge = React.memo(({
 
   const lastStatusRecently = lastSeen && lastSeen >= statusDebounceThreshold;
   const lastPuzzleRecently = lastPuzzle && lastPuzzle >= statusDebounceThreshold;
+  const puzzleCountdownDebounce = lastPuzzle && lastPuzzle >= relativeDebounceThreshold;
   const lastSeenRecently = lastStatusRecently || lastPuzzleRecently;
 
   const statusDisplay = useMemo(() => {
@@ -433,7 +435,7 @@ const UserStatusBadge = React.memo(({
     const puzzleLabel =
       <span><strong><FontAwesomeIcon icon={faPuzzlePiece} fixedWidth />&nbsp;
       {puzzleName}</strong>
-      { puzzleStatus !== 'online' && lastPuzzle ? (<span> <RelativeTime
+      { puzzleStatus !== 'online' && lastPuzzle && !puzzleCountdownDebounce ? (<span> <RelativeTime
       date={lastPuzzle}
       minimumUnit="second"
       maxElements={1}

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -383,6 +383,11 @@ const UserStatusBadge = React.memo(({
   huntPuzzles: PuzzleType[];
 }) => {
 
+  if (!huntId) {
+    // we don't show statuses on the all list
+    return
+  }
+
   if (!statusObj) {
     // we should display users as offline if we don't have data on them
     return <StatusDiv>

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -414,7 +414,7 @@ const UserStatusBadge = React.memo(({
   const puzzleLabel =
     <span><strong><FontAwesomeIcon icon={faPuzzlePiece} fixedWidth />&nbsp;
     {puzzleName}</strong>
-    { puzzleStatusString !== 'Online' ? (<span> <RelativeTime
+    { puzzleStatus !== 'online' ? (<span> <RelativeTime
     date={lastPuzzle}
     minimumUnit="second"
     maxElements={1}
@@ -430,7 +430,7 @@ const UserStatusBadge = React.memo(({
     ) : null
   }
   {
-    puzzleStatusString !== 'Online' && lastPuzzle ? (
+    puzzleStatus !== 'online' && lastPuzzle ? (
       ', last active on puzzle: ' + shortCalendarTimeFormat(lastPuzzle)
     ) : lastPuzzle ? ', currently active on puzzle' : null
   }

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -384,8 +384,9 @@ const UserStatusBadge = React.memo(({
 }) => {
 
   if (!statusObj) {
+    // we should display users as offline if we don't have data on them
     return <StatusDiv>
-      <OverlayTrigger placement="top" overlay={<Tooltip>Offline (never seen)</Tooltip>}>
+      <OverlayTrigger placement="top" overlay={<Tooltip>Offline<br/>(not seen in last four days)</Tooltip>}>
           <ButtonGroup size="sm">
               <Button
               variant='outline-secondary'
@@ -396,71 +397,89 @@ const UserStatusBadge = React.memo(({
       </OverlayTrigger>
     </StatusDiv>;
   }
-  const fiveMinutesAgo = new Date(Date.now() - 2 * 60 * 1000);
-  const lastSeen = statusObj.status.at;
-  const lastPuzzle = statusObj.puzzleStatus.at;
-  const lastStatusRecently = lastSeen >= fiveMinutesAgo;
-  const lastPuzzleRecently = statusObj.puzzleStatus.at >= fiveMinutesAgo;
+
+  const [lastSeen, setLastSeen] = useState<Date | null>(statusObj?.status?.at || null);
+  const [lastPuzzle, setLastPuzzle] = useState<Date | null>(statusObj?.puzzleStatus?.at || null);
+  const [timeNow, setTimeNow] = useState<Date | null>(new Date() || null);
+  const statusDebounceThreshold = new Date(Date.now() - 2 * 60 * 1000);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setLastSeen(statusObj?.status?.at || null);  // Update state every second
+      setLastPuzzle(statusObj?.puzzleStatus?.at || null);
+      setTimeNow(new Date());
+    }, 1000); // Update every 1000ms (1 second)
+
+    return () => clearInterval(intervalId);
+  }, [statusObj]);
+
+  const lastStatusRecently = lastSeen && lastSeen >= statusDebounceThreshold;
+  const lastPuzzleRecently = lastPuzzle && lastPuzzle >= statusDebounceThreshold;
   const lastSeenRecently = lastStatusRecently || lastPuzzleRecently;
 
-  const userStatus = statusObj.status.status;
-  const puzzleStatus = statusObj.puzzleStatus.status;
-  const puzzleId = statusObj.puzzleStatus.puzzle;
-  const puzzleName = puzzleId ? huntPuzzles[puzzleId] : null
+  const statusDisplay = useMemo(() => {
+    const userStatus = statusObj?.status?.status;
+    const puzzleStatus = statusObj?.puzzleStatus?.status;
+    const puzzleId = statusObj?.puzzleStatus?.puzzle;
+    const puzzleName = puzzleId ? huntPuzzles[puzzleId] : null;
 
-  const tooltipText = "ONLINE";
-  const statusString = (userStatus === 'offline' && !lastSeenRecently) ? 'Offline' : (userStatus === 'away' && !lastSeenRecently) ? 'Away' : 'Online';
-  const puzzleStatusString = (puzzleStatus === 'offline' && !lastPuzzleRecently) ? 'Offline' : (puzzleStatus === 'away' && !lastPuzzleRecently) ? 'Away' : 'Online';
-  const puzzleLabel =
-    <span><strong><FontAwesomeIcon icon={faPuzzlePiece} fixedWidth />&nbsp;
-    {puzzleName}</strong>
-    { puzzleStatus !== 'online' ? (<span> <RelativeTime
-    date={lastPuzzle}
-    minimumUnit="second"
-    maxElements={1}
-  /></span>) : null } </span>;
-  const tooltip = <span> {statusString}
-  {
-    userStatus !== 'online' ? (
-      <span>, last seen: {shortCalendarTimeFormat(lastSeen)}&nbsp;(<RelativeTime
-        date={lastSeen}
-        minimumUnit="second"
-        maxElements={1}
-      />)</span>
-    ) : null
-  }
-  {
-    puzzleStatus !== 'online' && lastPuzzle ? (
-      ', last active on puzzle: ' + shortCalendarTimeFormat(lastPuzzle)
-    ) : lastPuzzle ? ', currently active on puzzle' : null
-  }
-  </span>;
+    const statusString = (userStatus === 'offline' && !lastSeenRecently) ? 'Offline' : (userStatus === 'away' && !lastSeenRecently) ? 'Away' : 'Online';
+    const puzzleStatusString = (puzzleStatus === 'offline' && !lastPuzzleRecently) ? 'Offline' : (puzzleStatus === 'away' && !lastPuzzleRecently) ? 'Away' : 'Online';
+    const puzzleLabel =
+      <span><strong><FontAwesomeIcon icon={faPuzzlePiece} fixedWidth />&nbsp;
+      {puzzleName}</strong>
+      { puzzleStatus !== 'online' && lastPuzzle ? (<span> <RelativeTime
+      date={lastPuzzle}
+      minimumUnit="second"
+      maxElements={1}
+    /></span>) : null } </span>;
+    const tooltip = <span> {statusString}
+    {
+      userStatus !== 'online' ? (
+        <span>, last seen: {shortCalendarTimeFormat(lastSeen)}&nbsp;(<RelativeTime
+          date={lastSeen}
+          minimumUnit="second"
+          maxElements={1}
+        />)</span>
+      ) : null
+    }
+    {
+      puzzleStatus !== 'online' && lastPuzzle ? (
+        ', last active on puzzle: ' + shortCalendarTimeFormat(lastPuzzle)
+      ) : lastPuzzle ? ', currently active on puzzle' : null
+    }
+    </span>;
 
-  return (
-    <StatusDiv>
-      <OverlayTrigger placement="top" overlay={<Tooltip>{tooltip}</Tooltip>}>
+    return (
+      <StatusDiv>
+        <OverlayTrigger placement="top" overlay={<Tooltip>{tooltip}</Tooltip>}>
           <ButtonGroup size="sm">
-            <Button variant={statusString === 'Online' ? 'success' : statusString === 'Away' ? 'warning' : 'secondary'}>
-              {
-                statusString === 'Online' ? (
-                  <strong>{statusString}</strong>
-                ) : <span>{statusString}</span>
-              }
+            <Button variant={statusString === 'Online' ? 'success' : statusString === 'Away' ? 'warning' : 'secondary'}> {/* Button JSX */}
+            {
+              statusString === 'Online' ? (
+                <strong>{statusString}</strong>
+               ): (<span>{statusString}</span>)
+            }
             </Button>
-          {
-            puzzleName ? (
+            {
+            puzzleId ? (
               <Button
-              variant={puzzleStatusString === 'Online' ? 'success' : puzzleStatusString === 'Away' ? 'warning' : 'secondary'}
-              href={`/hunts/${huntId}/puzzles/${puzzleId}`}
+                variant={puzzleStatusString === 'Online' ? 'success' : puzzleStatusString === 'Away' ? 'warning' : 'secondary'}
+                href={`/hunts/${huntId}/puzzles/${puzzleId}`}
               >
                 {puzzleLabel}
               </Button>
             ) : null
-          }
+            }
           </ButtonGroup>
-      </OverlayTrigger>
-    </StatusDiv>
-  );
+        </OverlayTrigger>
+      </StatusDiv>
+    );
+  }, [
+    statusObj, lastSeenRecently, lastPuzzleRecently, lastSeen, lastPuzzle, huntPuzzles, timeNow,
+  ]);
+
+  return statusDisplay;
 });
 
 const ProfileList = ({

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -13,7 +13,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { OverlayTrigger } from "react-bootstrap";
+import { ButtonGroup, OverlayTrigger } from "react-bootstrap";
 import Alert from "react-bootstrap/Alert";
 import Badge from "react-bootstrap/Badge";
 import Button from "react-bootstrap/Button";
@@ -41,6 +41,12 @@ import generateHuntInvitationCode from "../../methods/generateHuntInvitationCode
 import promoteOperator from "../../methods/promoteOperator";
 import syncHuntDiscordRole from "../../methods/syncHuntDiscordRole";
 import Avatar from "./Avatar";
+import useTypedSubscribe from "../hooks/useTypedSubscribe";
+import puzzlesForHunt from "../../lib/publications/puzzlesForHunt";
+import Puzzles, { PuzzleType } from "../../lib/models/Puzzles";
+import RelativeTime from "./RelativeTime";
+import { faPuzzlePiece } from "@fortawesome/free-solid-svg-icons";
+import { shortCalendarTimeFormat } from "../../lib/calendarTimeFormat";
 
 const ProfilesSummary = styled.div`
   text-align: right;
@@ -72,6 +78,10 @@ const OperatorBox = styled.div`
   * {
     margin: 0 0.25rem;
   }
+`;
+
+const StatusDiv = styled.div`
+  margin-left: 0.5rem;
 `;
 
 const StyledLinkButton: FC<ComponentPropsWithRef<typeof Button>> = styled(
@@ -363,6 +373,84 @@ const DisableInvitationLinkModal = ({
   );
 };
 
+const UserStatusBadge = React.memo(({
+  statusObj,
+  huntId,
+  huntPuzzles,
+}: {
+  statusObj: Record<string, any>;
+  huntId: string | undefined;
+  huntPuzzles: PuzzleType[];
+}) => {
+  const fiveMinutesAgo = new Date(Date.now() - 1 * 60 * 1000);
+  const lastSeen = statusObj.status.at;
+  const lastPuzzle = statusObj.puzzleStatus.at;
+  const lastStatusRecently = lastSeen >= fiveMinutesAgo;
+  const lastPuzzleRecently = statusObj.puzzleStatus.at >= fiveMinutesAgo;
+  const lastSeenRecently = lastStatusRecently || lastPuzzleRecently;
+
+  const userStatus = statusObj.status.status;
+  const puzzleStatus = statusObj.puzzleStatus.status;
+  const puzzleId = statusObj.puzzleStatus.puzzle;
+  const puzzleName = puzzleId ? huntPuzzles[puzzleId] : null
+
+  const tooltipText = "ONLINE";
+  const statusString = (userStatus === 'offline' && !lastSeenRecently) ? 'Offline' : (userStatus === 'away' && !lastSeenRecently) ? 'Away' : 'Online';
+  const puzzleStatusString = (puzzleStatus === 'offline' && !lastPuzzleRecently) ? 'Offline' : (puzzleStatus === 'away' && !lastPuzzleRecently) ? 'Away' : 'Online';
+  const puzzleLabel =
+    <span><strong><FontAwesomeIcon icon={faPuzzlePiece} fixedWidth />&nbsp;
+    {puzzleName}</strong>
+    { puzzleStatusString !== 'Online' ? (<span> <RelativeTime
+    date={lastPuzzle}
+    terse
+    minimumUnit="second"
+    maxElements={1}
+  /> ago</span>) : null } </span>;
+  const tooltip = <span> {statusString}
+  {
+    statusString !== 'Online' ? (
+      <span>, last seen: {shortCalendarTimeFormat(lastSeen)}&nbsp;(<RelativeTime
+        date={lastSeen}
+        terse
+        minimumUnit="second"
+        maxElements={1}
+      />&nbsp;ago)</span>
+    ) : null
+  }
+  {
+    puzzleStatusString !== 'Online' && lastPuzzle ? (
+      ', last active on puzzle:' + shortCalendarTimeFormat(lastPuzzle)
+    ) : lastPuzzle ? ', currently active on puzzle' : null
+  }
+  </span>;
+
+  return (
+    <StatusDiv>
+      <OverlayTrigger placement="top" overlay={<Tooltip>{tooltip}</Tooltip>}>
+          <ButtonGroup size="sm">
+            <Button variant={statusString === 'Online' ? 'success' : statusString === 'Away' ? 'warning' : 'secondary'}>
+              {
+                statusString === 'Online' ? (
+                  <strong>{statusString}</strong>
+                ) : <span>{statusString}</span>
+              }
+            </Button>
+          {
+            puzzleName ? (
+              <Button
+              variant={puzzleStatusString === 'Online' ? 'success' : puzzleStatusString === 'Away' ? 'warning' : 'secondary'}
+              href={`/hunts/${huntId}/puzzles/${puzzleId}`}
+              >
+                {puzzleLabel}
+              </Button>
+            ) : null
+          }
+          </ButtonGroup>
+      </OverlayTrigger>
+    </StatusDiv>
+  );
+});
+
 const ProfileList = ({
   hunt,
   canInvite,
@@ -372,6 +460,7 @@ const ProfileList = ({
   users,
   roles,
   invitationCode,
+  userStatuses,
 }: {
   hunt?: HuntType;
   canInvite?: boolean;
@@ -381,7 +470,9 @@ const ProfileList = ({
   users: Meteor.User[];
   roles?: Record<string, string[]>;
   invitationCode?: string;
+  userStatuses?: Record<string, Record<string, Record<string, any>>>;
 }) => {
+
   const [searchString, setSearchString] = useState<string>("");
 
   const searchBarRef = useRef<HTMLInputElement>(null); // Wrong type but I should fix it
@@ -622,6 +713,18 @@ const ProfileList = ({
   }, [hunt]);
 
   const matching = users.filter(matcher);
+
+  const huntId = hunt?._id;
+
+  const huntPuzzlesStatus = useTypedSubscribe(puzzlesForHunt, {huntId});
+  const huntPuzzlesLoading = huntPuzzlesStatus();
+
+  const huntPuzzles: PuzzleType[] | [] = useTracker(
+    () => huntPuzzlesLoading ? [] : Puzzles.find({hunt: huntId}).fetch().reduce((arr, puz)=>{
+      arr[puz._id] = puz.title;
+      return arr;
+    }, {}));
+
   return (
     <div>
       <h1>List of hunters</h1>
@@ -655,23 +758,31 @@ const ProfileList = ({
         {inviteToHuntItem}
         {matching.map((user) => {
           const name = user.displayName ?? "<no name provided>";
+          const userStatus = userStatuses?.[user._id];
+
           return (
             <ListGroupItem
               key={user._id}
-              action
-              as={Link}
-              to={
-                hunt
-                  ? `/hunts/${hunt._id}/hunters/${user._id}`
-                  : `/users/${user._id}`
-              }
               className="p-1"
             >
               <ListItemContainer>
                 <ImageBlock>
                   <Avatar {...user} size={40} />
                 </ImageBlock>
+                <Link to={
+                hunt
+                  ? `/hunts/${hunt._id}/hunters/${user._id}`
+                  : `/users/${user._id}`
+              }>
                 {name}
+                </Link>
+                {userStatus && (
+                  <UserStatusBadge
+                  statusObj={userStatus}
+                  huntId={huntId}
+                  huntPuzzles={huntPuzzles}
+                  />
+                )}
                 {hunt && canMakeOperator && (
                   <OperatorControls hunt={hunt} user={user} />
                 )}

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -59,7 +59,7 @@ import { mediaBreakpointDown } from "./styling/responsive";
 
 const ViewControls = styled.div<{ $canAdd?: boolean }>`
   display: grid;
-  grid-template-columns: auto auto auto 1fr;
+  grid-template-columns: auto auto auto auto 1fr;
   align-items: end;
   gap: 1em;
   margin-bottom: 1em;

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -21,7 +21,7 @@ import FormLabel from "react-bootstrap/FormLabel";
 import InputGroup from "react-bootstrap/InputGroup";
 import ToggleButton from "react-bootstrap/ToggleButton";
 import ToggleButtonGroup from "react-bootstrap/ToggleButtonGroup";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import styled, { css } from "styled-components";
 import { sortedBy } from "../../lib/listUtils";
 import Bookmarks from "../../lib/models/Bookmarks";
@@ -371,6 +371,24 @@ const PuzzleListView = ({
       addModalRef.current.show();
     }
   }, []);
+
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const urlParams = new URLSearchParams(url.hash.slice(1));
+    const hashTitle = urlParams.get("title");
+    const hashUrl = urlParams.get("url");
+
+    const existingPuzzle = Puzzles.findOne({url: {$regex: `^${hashUrl}`}})
+
+    if (existingPuzzle) {
+      navigate(`./${existingPuzzle._id}`);
+    } else if ( hashTitle && hashUrl && addModalRef) {
+      addModalRef?.current?.show();
+      addModalRef?.current?.populateForm({title:hashTitle, url:hashUrl})
+    }
+  });
 
   const renderList = useCallback(
     (

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -48,6 +48,8 @@ enum PuzzleModalFormSubmitState {
 
 export type PuzzleModalFormHandle = {
   show: () => void;
+  populateForm: (data: { title: string; url: string }) => void; // Add this line
+  submitForm: () => void; // Add this line
 };
 
 const PuzzleModalForm = React.forwardRef(
@@ -183,6 +185,7 @@ const PuzzleModalForm = React.forwardRef(
             setUrlDirty(false);
             setTagsDirty(false);
             setExpectedAnswerCountDirty(false);
+            window.location.hash = "";
             callback();
           }
         });
@@ -233,6 +236,16 @@ const PuzzleModalForm = React.forwardRef(
 
     useImperativeHandle(forwardedRef, () => ({
       show,
+      // Add this populateForm method:
+      populateForm: (data: { title: string; url: string }) => {
+        setTitle(data.title);
+        setUrl(data.url);
+      },
+      submitForm: () => {
+        if (formRef.current) {
+          formRef.current.submit();
+        }
+      },
     }));
 
     useEffect(() => {

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -314,7 +314,7 @@ const PuzzleModalForm = React.forwardRef(
           }
           setLastAutoPopulatedTitle(formattedTitle);
         } catch (error) {
-          console.error("Invalid URL:", error);
+          // console.debug("Invalid URL, probably there's no URL:", error);
         }
       }, [url]);
 

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -2027,6 +2027,17 @@ const PuzzlePage = React.memo(() => {
   const huntId = useParams<"huntId">().huntId!;
   const puzzleId = useParams<"puzzleId">().puzzleId!;
 
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      const status = document.visibilityState === 'visible' ? 'online' : 'away';
+      Meteor.subscribe('userStatus.inc', huntId, 'puzzleStatus', status, puzzleId);
+    };
+    handleVisibilityChange();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [huntId]);
+
   // Add the current user to the collection of people viewing this puzzle.
   const subscribersTopic = `puzzle:${puzzleId}`;
   useSubscribe("subscribers.inc", subscribersTopic, {
@@ -2083,7 +2094,7 @@ const PuzzlePage = React.memo(() => {
     [puzzleDataLoading, chatDataLoading],
   );
   // Sort by created at so that the "first" document always has consistent meaning
-  const document = useTracker(
+  const doc = useTracker(
     () =>
       puzzleDataLoading
         ? undefined
@@ -2189,7 +2200,7 @@ const PuzzlePage = React.memo(() => {
     <PuzzlePageMetadata
       puzzle={activePuzzle}
       bookmarked={bookmarked}
-      document={document}
+      document={doc}
       displayNames={displayNames}
       isDesktop={isDesktop}
     />
@@ -2273,7 +2284,7 @@ const PuzzlePage = React.memo(() => {
             {chat}
             <PuzzleContent>
               {metadata}
-              <PuzzlePageMultiplayerDocument document={document} />
+              <PuzzlePageMultiplayerDocument document={doc} />
               {debugPane}
             </PuzzleContent>
           </SplitPanePlus>

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -119,6 +119,7 @@ import {
   SolvedPuzzleBackgroundColor,
 } from "./styling/constants";
 import { mediaBreakpointDown } from "./styling/responsive";
+import setUserStatus from "../../methods/setUserStatus";
 
 // Shows a state dump as an in-page overlay when enabled.
 const DEBUG_SHOW_CALL_STATE = false;
@@ -2030,13 +2031,18 @@ const PuzzlePage = React.memo(() => {
   useEffect(() => {
     const handleVisibilityChange = () => {
       const status = document.visibilityState === 'visible' ? 'online' : 'away';
-      Meteor.subscribe('userStatus.inc', huntId, 'puzzleStatus', status, puzzleId);
+      setUserStatus.call({hunt:huntId, type:'puzzleStatus', status:status, puzzle:puzzleId});
     };
     handleVisibilityChange();
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
-  }, [huntId]);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      setUserStatus.call({hunt:huntId, type:'puzzleStatus', status:'offline', puzzle:puzzleId});
+    };
+  }, [huntId, puzzleId]);
+
+  useSubscribe('userStatus.inc', huntId, 'puzzleStatus', document.visibilityState === 'visible' ? 'online' : 'away', puzzleId);
 
   // Add the current user to the collection of people viewing this puzzle.
   const subscribersTopic = `puzzle:${puzzleId}`;

--- a/imports/client/components/Routes.tsx
+++ b/imports/client/components/Routes.tsx
@@ -29,6 +29,7 @@ import { AuthenticatedPage, UnauthenticatedPage } from "./authentication";
 import TagManagerApp from "./TagManagerApp";
 import TagManagerPage from "./TagManagerPage";
 import TagEditPage from "./TagEditPage";
+import TagBulkEditPage from "./TagBulkEditPage";
 
 const HuntEditPage = React.lazy(() => import("./HuntEditPage"));
 const SetupPage = React.lazy(() => import("./SetupPage"));
@@ -57,12 +58,8 @@ export const AuthenticatedRouteList: RouteObject[] = [
             ],
           },
           { path: "puzzles/:puzzleId", element: <PuzzlePage /> },
-          { path: "tags", element: <TagManagerApp />,
-            children: [
-              { path: "", element: <TagManagerPage /> },
-              { path: ":tagId", element: <TagEditPage /> },
-            ]
-           },
+          { path: "tags", element: <TagBulkEditPage />},
+          { path: "tags2", element: <TagManagerPage />},
           { path: "puzzles", element: <PuzzleListPage /> },
           { path: "edit", element: <HuntEditPage /> },
           { path: "more", element: <MoreAppPage /> },

--- a/imports/client/components/Routes.tsx
+++ b/imports/client/components/Routes.tsx
@@ -17,6 +17,7 @@ import HuntersApp from "./HuntersApp";
 import JoinHunt from "./JoinHunt";
 import Loading from "./Loading";
 import LoginForm from "./LoginForm";
+import MoreAppPage from "./MoreAppPage";
 import PasswordResetForm from "./PasswordResetForm";
 import ProfilePage from "./ProfilePage";
 import PuzzleListPage from "./PuzzleListPage";
@@ -64,6 +65,7 @@ export const AuthenticatedRouteList: RouteObject[] = [
            },
           { path: "puzzles", element: <PuzzleListPage /> },
           { path: "edit", element: <HuntEditPage /> },
+          { path: "more", element: <MoreAppPage /> },
           { path: "", element: <Navigate to="puzzles" replace /> },
         ],
       },

--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -323,7 +323,7 @@ const Tag = (props: TagProps) => {
   const isMetaFor = name.lastIndexOf("meta-for:", 0) === 0;
   const isNeeds = name.lastIndexOf("needs:", 0) === 0;
   const isPriority = name.lastIndexOf("priority:", 0) === 0;
-  const isLocation = name.lastIndexOf("location:", 0) === 0;
+  const isLocation = name.lastIndexOf("location:", 0) === 0 || name.lastIndexOf("loc:") === 0;
 
   // Browsers won't word-break on hyphens, so suggest
   // Use wbr instead of zero-width space to make copy-paste reasonable

--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -72,6 +72,7 @@ const TagDiv = styled.div<{
   $isMetaFor: boolean;
   $isNeeds: boolean;
   $isPriority: boolean;
+  $isLocation?: boolean;
 }>`
   display: inline-flex;
   align-items: center;
@@ -131,6 +132,11 @@ const TagDiv = styled.div<{
     $isPriority &&
     css`
       background-color: #aaf;
+    `}
+  ${({ $isLocation }) =>
+    $isLocation &&
+    css`
+      background-color: #aaffc3;
     `}
 `;
 
@@ -317,6 +323,7 @@ const Tag = (props: TagProps) => {
   const isMetaFor = name.lastIndexOf("meta-for:", 0) === 0;
   const isNeeds = name.lastIndexOf("needs:", 0) === 0;
   const isPriority = name.lastIndexOf("priority:", 0) === 0;
+  const isLocation = name.lastIndexOf("location:", 0) === 0;
 
   // Browsers won't word-break on hyphens, so suggest
   // Use wbr instead of zero-width space to make copy-paste reasonable
@@ -355,6 +362,7 @@ const Tag = (props: TagProps) => {
       $isMetaFor={isMetaFor}
       $isNeeds={isNeeds}
       $isPriority={isPriority}
+      $isLocation={isLocation}
     >
       {title}
       {props.onRemove && (

--- a/imports/client/components/TagBulkEditPage.tsx
+++ b/imports/client/components/TagBulkEditPage.tsx
@@ -1,0 +1,644 @@
+import { useTracker } from "meteor/react-meteor-data";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus";
+import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus";
+import React, { useCallback, useRef, useState } from "react";
+import { Alert, ButtonGroup, InputGroup } from "react-bootstrap";
+import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
+import Container from "react-bootstrap/Container";
+import Form from "react-bootstrap/Form";
+import FormControl, { FormControlProps } from "react-bootstrap/FormControl";
+import FormGroup from "react-bootstrap/FormGroup";
+import FormLabel from "react-bootstrap/FormLabel";
+import Row from "react-bootstrap/Row";
+import { FormProps, useParams, useSearchParams } from "react-router-dom"
+import { useBreadcrumb } from "../hooks/breadcrumb";
+import useTypedSubscribe from "../hooks/useTypedSubscribe";
+import Tags, {TagType} from "../../lib/models/Tags";
+import puzzlesForPuzzleList from "../../lib/publications/puzzlesForPuzzleList";
+import ActionButtonRow from "./ActionButtonRow";
+import Puzzles, {PuzzleType} from "../../lib/models/Puzzles";
+import { indexedById } from "../../lib/listUtils";
+import styled, { css } from "styled-components";
+import { computeSolvedness, Solvedness } from "../../lib/solvedness";
+import { backgroundColorLookupTable } from "./styling/constants";
+import { mediaBreakpointDown } from "./styling/responsive";
+import TagList from "./TagList";
+import addPuzzleTag from "../../methods/addPuzzleTag";
+import removePuzzleTag from "../../methods/removePuzzleTag";
+import { faCross, faTags, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes";
+import ModalForm, { ModalFormHandle } from "./ModalForm";
+import renameTag from "../../methods/renameTag";
+import { faEraser } from "@fortawesome/free-solid-svg-icons/faEraser";
+import Select, { ActionMeta } from "react-select";
+import Hunts from "../../lib/models/Hunts";
+
+enum SubmitState {
+  IDLE = "idle",
+  SUBMITTING = "submitting",
+  SUCCESS = "success",
+  FAILED = "failed",
+}
+
+type TagSelectOption = { value: string; label: string };
+
+const SearchFormGroup = styled(FormGroup)`
+  grid-column: -3;
+  ${mediaBreakpointDown(
+    "sm",
+    css`
+      grid-column: 1 / -1;
+    `,
+  )}
+`;
+
+const PuzzleListToolbar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  // align-items: baseline;
+  margin-bottom: 0.5em;
+`;
+
+const TagPuzzleDiv = styled.div<{
+  $solvedness: Solvedness;
+}>`
+  ${({ $solvedness }) => css`
+    background-color: ${backgroundColorLookupTable[$solvedness]};
+  `}
+
+  display: flex;
+  flex-direction: row;
+  align-items: first baseline;
+  justify-content: flex-start;
+  line-height: 24px;
+  padding: 4px 2px;
+  margin-bottom: 4px;
+  ${mediaBreakpointDown(
+    "xs",
+    css`
+      flex-wrap: wrap;
+    `,
+  )}
+`;
+
+const PuzzleColumn = styled.div`
+  padding: 0 2px;
+  display: inline-block;
+  flex: none;
+  overflow: hidden;
+`;
+
+const PuzzleControlButtonsColumn = styled(PuzzleColumn)`
+  align-self: flex-start;
+  order: -1;
+`;
+
+const PuzzleTitleColumn = styled(PuzzleColumn)`
+  flex: 4;
+  overflow-wrap: break-word;
+  order: -1;
+`;
+
+const TagListColumn = styled(TagList)`
+  padding: 0 2px;
+  display: inline-block;
+  flex: 3;
+  margin: -2px -4px -2px 0;
+  ${mediaBreakpointDown(
+    "xs",
+    css`
+      flex: 0 0 100%;
+    `,
+  )}
+`;
+
+
+const TagToggleButtons = React.memo(
+  ({
+    puzzle,
+    allTags,
+    bulkTags,
+  }: {
+    puzzle: PuzzleType;
+    allTags: TagType[];
+    bulkTags: string[];
+  }) => {
+
+
+    const tagNamesForIds = useCallback(
+      (tagIds: string[]) => {
+        const tagNames: Record<string, string> = {};
+        allTags.forEach((t) => {
+          tagNames[t._id] = t.name;
+        });
+        return tagIds.map((t) => tagNames[t] ?? t);
+      },
+      [allTags],
+    );
+
+    const puzzleId = puzzle._id;
+    const removeBulkTagsFromPuzzle = useCallback (() => {
+      bulkTags.forEach((tagId) => {
+        if(puzzle.tags.includes(tagId)) {
+          removePuzzleTag.call({ puzzleId, tagId });
+        }
+      });
+        return false;
+      },
+      [puzzleId, bulkTags, puzzle.tags]
+    );
+    const addBulkTagsToPuzzle = useCallback (() => {
+
+      bulkTags.forEach((tagId)=>{
+        if (!puzzle.tags.includes(tagId)) {
+          const tagName = tagNamesForIds([tagId])[0] ?? "";
+          addPuzzleTag.call({ puzzleId,  tagName})
+        }
+      });
+        return false;
+      },
+      [puzzleId, bulkTags, puzzle.tags]
+    );
+
+    const disableBulkTagActions = bulkTags.length === 0;
+    const disableBulkAdd = bulkTags.every((t)=> puzzle.tags.includes(t));
+    const disableBulkRemove = bulkTags.every((t)=> !puzzle.tags.includes(t));
+
+    return (
+      <ButtonGroup size="sm">
+      <Button
+      size="sm"
+      variant="danger"
+      title="Remove tag"
+      onClick={removeBulkTagsFromPuzzle}
+      disabled={disableBulkTagActions || disableBulkRemove}
+      >
+        <FontAwesomeIcon fixedWidth icon={faMinus} />
+      </Button>
+      <Button
+      size="sm"
+      variant="success"
+      title="Add tag"
+      onClick={addBulkTagsToPuzzle}
+      disabled={disableBulkTagActions || disableBulkAdd}
+      >
+       <FontAwesomeIcon fixedWidth icon={faPlus} />
+      </Button>
+      </ButtonGroup>
+    )
+
+  }
+);
+
+
+const TagBulkEditPage = () => {
+  const huntId = useParams<{ huntId: string }>().huntId!;
+  useTypedSubscribe(puzzlesForPuzzleList, {
+    huntId,
+    includeDeleted: true,
+  });
+  const hunt = useTracker(() => Hunts.findOne(huntId)!, [huntId]);
+
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [dirtyRename, setDirtyRename] = useState<Boolean>(false);
+  const [submitState, setSubmitState] = useState<SubmitState>(SubmitState.IDLE);
+
+
+  const allPuzzles = useTracker(
+    () => Puzzles.find({ hunt: huntId }).fetch(),
+    [huntId],
+  );
+
+  const [bulkTags, setBulkTags] = useState<string[]>([]);
+
+
+  const [searchString, setSearchString] = useState<string>("");
+
+  const [selectedTag, setSelectedTag] = useState<string|undefined>("");
+
+  const onNameChanged = useCallback<NonNullable<FormControlProps["onChange"]>>(
+    (e) => {
+      setNewTagName(e.currentTarget.value);
+      setDirtyRename(tagToRename?.name.trim() != newTagName?.trim());
+    },
+    [],
+  );
+
+  const tagToRename = useTracker(
+    () => selectedTag ? Tags.findOne({_id: selectedTag}) : null,
+    [selectedTag, submitState]
+  )
+  const [newTagName, setNewTagName] = useState<string|undefined>(tagToRename?.name ?? "");
+
+  const allTags = useTracker(
+    () => Tags.find({ hunt: huntId }).fetch(),
+    [huntId],
+  );
+
+  const selectOptions: TagSelectOption[] = useTracker(
+    () =>
+      allTags.map((t) => {
+        return { value: t._id, label: t.name };
+      })
+    ,
+    [allTags],
+  )
+
+    const onRenameTagChanged = useCallback(
+      (
+        value: TagSelectOption,
+        action: ActionMeta<TagSelectOption>,
+      ) => {
+        setSelectedTag(value.value);
+        setNewTagName(value.label);
+        setDirtyRename(false);
+      },
+      [],
+    );
+
+    const onSelectedTagsChanged = useCallback(
+      (
+        value: readonly TagSelectOption[],
+        action: ActionMeta<TagSelectOption>,
+      ) => {
+        let newRoles = [];
+        switch (action.action) {
+          case "clear":
+          case "deselect-option":
+          case "remove-value":
+          case "create-option":
+          case "pop-value":
+          case "select-option":
+                newRoles = value.map((v) => v.value);
+                break;
+          default:
+            return;
+        }
+        setBulkTags(newRoles);
+      },
+      [],
+    );
+
+    const compileMatcher = useCallback(
+      (searchKeys: string[]): ((p: PuzzleType) => boolean) => {
+        const tagNames: Record<string, string> = {};
+        allTags.forEach((t) => {
+          tagNames[t._id] = t.name.toLowerCase();
+        });
+        const lowerSearchKeys = searchKeys.map((key) => key.toLowerCase());
+        return function (puzzle) {
+          const titleWords = puzzle.title.toLowerCase().split(" ");
+          return lowerSearchKeys.every((key) => {
+            // Every key should match at least one of the following:
+            // * prefix of word in title
+            // * substring of any answer
+            // * substring of any tag
+            if (titleWords.some((word) => word.startsWith(key))) {
+              return true;
+            }
+
+            if (
+              puzzle.answers.some((answer) => {
+                return answer.toLowerCase().includes(key);
+              })
+            ) {
+              return true;
+            }
+
+            const tagMatch = puzzle.tags.some((tagId) => {
+              const tagName = tagNames[tagId];
+              return tagName?.includes(key);
+            });
+
+            if (tagMatch) {
+              return true;
+            }
+
+            return false;
+          });
+        };
+      },
+      [allTags],
+    );
+
+    const puzzlesMatchingSearchString = useCallback(
+      (puzzles: PuzzleType[]): PuzzleType[] => {
+        const searchKeys = searchString.split(" ");
+        if (searchKeys.length === 1 && searchKeys[0] === "") {
+          // No search query, so no need to do fancy search computation
+          return puzzles;
+        } else {
+          const searchKeysWithEmptyKeysRemoved = searchKeys.filter((key) => {
+            return key.length > 0;
+          });
+          const isInteresting = compileMatcher(searchKeysWithEmptyKeysRemoved);
+          return puzzles.filter(isInteresting);
+        }
+      },
+      [searchString, compileMatcher],
+    );
+
+  const matchingSearch = puzzlesMatchingSearchString(allPuzzles);
+
+    const deleteModalRef = useRef<ModalFormHandle>(null);
+    const addModalRef = useRef<ModalFormHandle>(null);
+    const onRemoveFromAll = useCallback(
+      ( callback: () => void) => {
+        matchingSearch.forEach((puzzle) => {
+          bulkTags.forEach((tagId) => {
+          const puzzleId = puzzle._id;
+          removePuzzleTag.call({puzzleId, tagId}, callback)
+        })
+      })
+      },
+      [huntId, bulkTags, matchingSearch]
+    );
+
+    const tagNamesForIds = useCallback(
+      (tagIds: string[]) => {
+        const tagNames: Record<string, string> = {};
+        allTags.forEach((t) => {
+          tagNames[t._id] = t.name;
+        });
+        return tagIds.map((t) => tagNames[t] ?? t);
+      },
+      [allTags],
+    );
+
+    const onAddToAll = useCallback(
+      ( callback: () => void) => {
+        matchingSearch.forEach((puzzle) => {
+            const tagNames = tagNamesForIds(bulkTags);
+            tagNames.forEach((tagName) => {
+            const puzzleId = puzzle._id;
+            // const tagName = tag?.name;
+            addPuzzleTag.call({puzzleId, tagName}, callback)
+          })
+        })
+      },
+      [huntId, bulkTags, matchingSearch]
+    );
+
+
+  const searchBarRef = useRef<HTMLInputElement>(null);
+
+  const onSearchStringChange: NonNullable<FormControlProps["onChange"]> =
+  useCallback(
+    (e) => {
+      setSearchString(e.currentTarget.value);
+    },
+    [setSearchString],
+  );
+
+  const clearSearch = useCallback(() => {
+    setSearchString("");
+  }, [setSearchString]);
+
+  const TagPuzzle = React.memo(
+    ({
+      puzzle,
+      allTags,
+      bulkTags,
+    }: {
+      puzzle: PuzzleType;
+      allTags: TagType[];
+      bulkTags: string[];
+    }) => {
+      const puzzleId = puzzle._id;
+      const huntId = puzzle.hunt;
+      const solvedness = computeSolvedness(puzzle);
+
+
+      const tagIndex = indexedById(allTags);
+      const puzzleTags = puzzle.tags.map((tagId) => {return tagIndex.get(tagId)});
+
+      return (
+      <TagPuzzleDiv $solvedness={solvedness}>
+      <PuzzleControlButtonsColumn>
+          <TagToggleButtons
+            puzzle={puzzle}
+            bulkTags={bulkTags}
+            allTags={allTags}
+          />
+      </PuzzleControlButtonsColumn>
+        <PuzzleTitleColumn>
+          {puzzle.title}
+        </PuzzleTitleColumn>
+          <TagListColumn
+            puzzle={puzzle}
+            tags={puzzleTags}
+            linkToSearch
+            popoverRelated={false}
+          />
+      </TagPuzzleDiv>
+      )
+    }
+  );
+
+  const PuzzlesForTagList = React.memo(
+    ({
+      puzzles,
+      allTags,
+      bulkTags,
+    }: {
+      puzzles: PuzzleType[];
+      allTags: TagType[];
+      bulkTags: string[];
+    }) => {
+      return (
+        <div>
+        {puzzles.map((puzzle) => {
+          return(
+            <TagPuzzle
+            key={puzzle._id}
+            puzzle={puzzle}
+            allTags={allTags}
+            bulkTags={bulkTags}
+            />)
+          })}
+          </div>
+      )
+    }
+  );
+
+  const renderList = useCallback (
+    (
+      allPuzzles: PuzzleType[],
+      allTags: TagType[],
+      bulkTags: string[],
+    ) => {
+      return <PuzzlesForTagList
+      puzzles={allPuzzles}
+      allTags={allTags}
+      bulkTags={bulkTags}
+      />
+    },
+    [allPuzzles, allTags, bulkTags]
+  )
+
+  const disableBulkTagActions = bulkTags.length === 0;
+
+  const showRemoveAllModal = useCallback(() => {
+    if (deleteModalRef.current) {
+      deleteModalRef.current.show();
+    }
+  }, []);
+
+  const showAddAllModal = useCallback(() => {
+    if (addModalRef.current) {
+      addModalRef.current.show();
+    }
+  }, []);
+
+  const disableRename = !dirtyRename || submitState === SubmitState.SUBMITTING;
+
+  const onUpdateCallback = useCallback(
+    (error?: Error) => {
+      if (error) {
+        setSubmitState(SubmitState.FAILED);
+        setErrorMessage(error.message);
+      } else {
+        setSubmitState(SubmitState.SUCCESS);
+        setErrorMessage("");
+      }
+    }
+  );
+
+  const onFormSubmit = useCallback<NonNullable<FormProps["onSubmit"]>>(
+    (e) => {
+      e.preventDefault();
+      setSubmitState(SubmitState.SUBMITTING);
+      renameTag.call({tagId: selectedTag, name: newTagName}, onUpdateCallback);
+    },
+    [selectedTag, newTagName]
+  )
+
+  return (
+    <Container>
+    <ModalForm
+      ref={deleteModalRef}
+      title="Remove tag from all"
+      submitLabel="Remove"
+      submitStyle="danger"
+      onSubmit={onRemoveFromAll}
+    >
+      Are you sure you want to remove this tag from {matchingSearch.length} puzzle{matchingSearch.length === 1 ? "" : "s"}?
+      {
+        allPuzzles.length === matchingSearch.length ? (
+          <Alert
+            variant="danger"
+          >
+            You are removing this tag from all puzzles!
+          </Alert>
+        ) : null
+      }
+    </ModalForm>
+    <ModalForm
+      ref={addModalRef}
+      title="Add tag to all"
+      submitLabel="Add"
+      submitStyle="success"
+      onSubmit={onAddToAll}
+    >
+      Are you sure you want to add this tag to {matchingSearch.length} puzzle{matchingSearch.length === 1 ? "" : "s"}?
+      {
+        allPuzzles.length === matchingSearch.length ? (
+          <Alert
+            variant="danger"
+            title="You are about to add this tag to all items!"
+          >
+            You are adding this tag to all puzzles!
+          </Alert>
+        ) : null
+      }
+    </ModalForm>
+      <h1>Tag Manager</h1>
+      <h2>Rename tag</h2>
+      <Form onSubmit={onFormSubmit}>
+        <FormGroup as={Row} className="mb-3">
+          <Col xs={5}>
+        <Select
+          id="tag-rename-selected-tag"
+          options={selectOptions}
+          onChange={onRenameTagChanged}
+        />
+        </Col>
+        <Col xs={5}>
+          <FormControl
+          id="tag-rename-new-name"
+          type="text"
+          onChange={onNameChanged}
+          placeholder={tagToRename?.name}
+          value={newTagName}
+          />
+        </Col>
+        <Col xs={2}>
+        <Button
+        variant="primary"
+        type="submit"
+        disabled={disableRename }
+        >
+          Rename
+        </Button>
+        </Col>
+        </FormGroup>
+      </Form>
+      <hr/>
+      <h2>Bulk add/remove tags</h2>
+      <FormGroup as={Row} className="mb-3">
+        <Col xs={8}>
+        <Select
+        id="tag-bulk-selected-tags"
+        isMulti
+        options={selectOptions}
+        onChange={onSelectedTagsChanged}
+        />
+        </Col>
+        <Col xs={4}>
+        <ButtonGroup>
+        <Button
+        variant="danger"
+        onClick={showRemoveAllModal}
+        disabled={disableBulkTagActions}
+        >
+        <FontAwesomeIcon fixedWidth icon={faTimes}></FontAwesomeIcon>
+          Remove from all
+        </Button>
+        <Button
+        variant="warning"
+        onClick={showAddAllModal}
+        disabled={disableBulkTagActions}
+        >
+          <FontAwesomeIcon fixedWidth icon={faTags}></FontAwesomeIcon>
+          Add to all
+        </Button>
+        </ButtonGroup>
+        </Col>
+      </FormGroup>
+      <SearchFormGroup>
+        <InputGroup>
+          <FormControl
+            id="jr-puzzle-search"
+            as="input"
+            type="text"
+            ref={searchBarRef}
+            placeholder="Filter by title, answer, or tag"
+            value={searchString}
+            onChange={onSearchStringChange}
+          />
+          <Button variant="secondary" onClick={clearSearch}>
+            <FontAwesomeIcon icon={faEraser} />
+          </Button>
+        </InputGroup>
+      </SearchFormGroup>
+      <PuzzleListToolbar>
+      <span>Showing {matchingSearch.length} of {allPuzzles.length} items</span>
+      </PuzzleListToolbar>
+      {renderList(matchingSearch, allTags, bulkTags)}
+    </Container>
+  );
+};
+
+export default TagBulkEditPage;

--- a/imports/lib/models/Hunts.ts
+++ b/imports/lib/models/Hunts.ts
@@ -49,6 +49,8 @@ const EditableHunt = z.object({
   memberDiscordRole: SavedDiscordObjectFields.optional(),
   // If true, this hunt will be displayed below other hunts
   isArchived: z.boolean().default(false),
+  // If set, this is an array of "default roles" for the hunt
+  defaultRoles: nonEmptyString.array().default([]),
 });
 export type EditableHuntType = z.infer<typeof EditableHunt>;
 const Hunt = withCommon(EditableHunt);
@@ -71,6 +73,7 @@ export const HuntPattern = {
   firehoseDiscordChannel: Match.Optional(SavedDiscordObjectPattern),
   memberDiscordRole: Match.Optional(SavedDiscordObjectPattern),
   isArchived: Match.Optional(Boolean),
+  defaultRoles: [String] as [StringConstructor],
 };
 
 const Hunts = new SoftDeletedModel("jr_hunts", Hunt);

--- a/imports/lib/models/PuzzleNotifications.ts
+++ b/imports/lib/models/PuzzleNotifications.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import type { ModelType } from "./Model";
+import SoftDeletedModel from "./SoftDeletedModel";
+import { foreignKey, nonEmptyString } from "./customTypes";
+import withCommon from "./withCommon";
+
+// A notification triggered by a chat message sent by a user.
+const PuzzleNotification = withCommon(
+  z.object({
+    // The userId of the user for whom this notification targets.
+    user: foreignKey,
+    // The hunt in which the puzzle resides.
+    hunt: foreignKey,
+    // The puzzle that generated this notification.
+    puzzle: foreignKey,
+    // The notification content.
+    content: nonEmptyString,
+  }),
+);
+
+const PuzzleNotifications = new SoftDeletedModel(
+  "jr_puzzlenotifications",
+  PuzzleNotification,
+);
+PuzzleNotifications.addIndex({ deleted: 1, user: 1 });
+export type PuzzleNotificationType = ModelType<typeof PuzzleNotifications>;
+
+export default PuzzleNotifications;

--- a/imports/lib/models/UserStatuses.ts
+++ b/imports/lib/models/UserStatuses.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import type { ModelType } from "../../lib/models/Model";
+import Model from "../../lib/models/Model";
+import { foreignKey, nonEmptyString } from "../../lib/models/customTypes";
+import { Id } from "../../lib/models/regexes";
+import withTimestamps from "../../lib/models/withTimestamps";
+
+export const UserStatus = withTimestamps(
+  z.object({
+    server: foreignKey,
+    // The connection ID is not technically a foreign key because it doesn't refer
+    // to another database record
+    connection: z.string().regex(Id),
+    user: foreignKey,
+    type: nonEmptyString,
+    status: nonEmptyString,
+    hunt: foreignKey,
+    puzzle: foreignKey.optional(),
+  }),
+);
+
+const UserStatuses = new Model("jr_userstatuses", UserStatus);
+UserStatuses.addIndex({ server: 1 });
+UserStatuses.addIndex({ hunt: 1 });
+UserStatuses.addIndex({ user: 1 });
+UserStatuses.addIndex({ type: 1 });
+UserStatuses.addIndex({ status: 1 });
+export type UserStatusType = ModelType<typeof UserStatuses>;
+
+export default UserStatuses;

--- a/imports/lib/publications/puzzleNotificationsForSelf.ts
+++ b/imports/lib/publications/puzzleNotificationsForSelf.ts
@@ -1,0 +1,5 @@
+import TypedPublication from "./TypedPublication";
+
+export default new TypedPublication<void>(
+  "PuzzleNotifications.publications.forSelf",
+);

--- a/imports/lib/publications/statusesForHuntUsers.ts
+++ b/imports/lib/publications/statusesForHuntUsers.ts
@@ -1,0 +1,5 @@
+import TypedPublication from "./TypedPublication";
+
+export default new TypedPublication<{ huntId: string }>(
+  "UserStatuses.publications.forHunt",
+);

--- a/imports/methods/dismissPuzzleNotification.ts
+++ b/imports/methods/dismissPuzzleNotification.ts
@@ -1,0 +1,5 @@
+import TypedMethod from "./TypedMethod";
+
+export default new TypedMethod<{ puzzleNotificationId: string }, void>(
+  "PuzzleNotifications.methods.dismiss",
+);

--- a/imports/methods/setUserStatus.ts
+++ b/imports/methods/setUserStatus.ts
@@ -1,0 +1,5 @@
+import TypedMethod from "./TypedMethod";
+
+export default new TypedMethod<{ hunt: string; type: string; status: string; puzzle?: string; }, void>(
+  "UserStatus.methods.setStatus",
+);

--- a/imports/server/GlobalHooks.ts
+++ b/imports/server/GlobalHooks.ts
@@ -4,6 +4,7 @@ import ChatNotificationHooks from "./hooks/ChatNotificationHooks";
 import DiscordHooks from "./hooks/DiscordHooks";
 import HooksRegistry from "./hooks/HooksRegistry";
 import TagCleanupHooks from "./hooks/TagCleanupHooks";
+import TagDingwordHooks from "./hooks/TagHooks";
 
 // Instantiate the application-global hookset list.
 const GlobalHooks = new HooksRegistry();
@@ -13,5 +14,6 @@ GlobalHooks.addHookSet(ChatNotificationHooks);
 GlobalHooks.addHookSet(TagCleanupHooks);
 GlobalHooks.addHookSet(ChatHooks);
 GlobalHooks.addHookSet(BookmarkNotificationHooks);
+GlobalHooks.addHookSet(TagDingwordHooks);
 
 export default GlobalHooks;

--- a/imports/server/addUserToHunt.ts
+++ b/imports/server/addUserToHunt.ts
@@ -85,6 +85,9 @@ export default async function addUserToHunt({
   email: string;
   invitedBy: string;
 }) {
+  const huntId = hunt._id;
+  const huntRoles = hunt.defaultRoles ?? [];
+
   let joineeUser = Accounts.findUserByEmail(email);
   const newUser = joineeUser === undefined;
   if (!joineeUser) {
@@ -111,6 +114,12 @@ export default async function addUserToHunt({
   await MeteorUsers.updateAsync(joineeUser._id, {
     $addToSet: { hunts: { $each: [hunt._id] } },
   });
+
+  if (huntRoles.length > 0) {
+    await MeteorUsers.updateAsync(joineeUser._id, {
+      $set:{[`roles.${huntId}`]: huntRoles},
+    });
+  }
   const joineeEmails = (joineeUser.emails ?? []).map((e) => e.address);
 
   hunt.mailingLists.forEach((listName) => {

--- a/imports/server/hooks/HooksRegistry.ts
+++ b/imports/server/hooks/HooksRegistry.ts
@@ -68,6 +68,14 @@ class HooksRegistry {
       }
     }
   }
+
+  async runNoPuzzleViewers(puzzleId: string) {
+    for (const hook of this.registeredHooks) {
+      if (hook.onNoPuzzleViewers) {
+        await hook.onNoPuzzleViewers(puzzleId);
+      }
+    }
+  }
 }
 
 export default HooksRegistry;

--- a/imports/server/hooks/HooksRegistry.ts
+++ b/imports/server/hooks/HooksRegistry.ts
@@ -60,6 +60,14 @@ class HooksRegistry {
       }
     }
   }
+
+  async runTagAddedHooks(puzzleId: string, tagId: string, adderId: string) {
+    for (const hook of this.registeredHooks) {
+      if (hook.onAddPuzzleTag) {
+        await hook.onAddPuzzleTag(puzzleId, tagId, adderId);
+      }
+    }
+  }
 }
 
 export default HooksRegistry;

--- a/imports/server/hooks/Hookset.ts
+++ b/imports/server/hooks/Hookset.ts
@@ -40,6 +40,9 @@ interface Hookset {
 
   // Triggered when a tag is removed from a puzzle
   onRemovePuzzleTag?: (puzzleId: string, tagName: string) => void | Promise<void>;
+
+  // Triggered when no one is looking at a puzzle anymore
+  onNoPuzzleViewers?: (puzzleId: string) => void | Promise<void>;
 }
 
 export default Hookset;

--- a/imports/server/hooks/Hookset.ts
+++ b/imports/server/hooks/Hookset.ts
@@ -34,6 +34,12 @@ interface Hookset {
   // Triggered when a new message is added to a puzzle's chat (either from a
   // user or e.g. in response to a guess transitioning state).
   onChatMessageCreated?: (chatMessageId: string) => void | Promise<void>;
+
+  // Triggered when a tag is added to a puzzle
+  onAddPuzzleTag?: (puzzleId: string, tagId: string, adderId: string) => void | Promise<void>;
+
+  // Triggered when a tag is removed from a puzzle
+  onRemovePuzzleTag?: (puzzleId: string, tagName: string) => void | Promise<void>;
 }
 
 export default Hookset;

--- a/imports/server/hooks/TagCleanupHooks.ts
+++ b/imports/server/hooks/TagCleanupHooks.ts
@@ -1,4 +1,4 @@
-import Puzzles from "../../lib/models/Puzzles";
+import Puzzles, { PuzzleType } from "../../lib/models/Puzzles";
 import Tags from "../../lib/models/Tags";
 import { computeSolvedness } from "../../lib/solvedness";
 import type Hookset from "./Hookset";
@@ -29,6 +29,31 @@ const TagCleanupHooks: Hookset = {
       {
         $pullAll: {
           tags: needsTagsIds,
+        },
+      },
+    );
+
+  },
+  async onNoPuzzleViewers(puzzleId: string){
+    const puzzle = await Puzzles.findOneAsync(puzzleId)!;
+
+    if (!puzzle) return;
+
+    const tags = await Tags.find({_id: { $in: puzzle.tags } }).fetchAsync();
+
+    const locationTags = tags.filter((tag) => tag.name.startsWith("location:"));
+
+    if( locationTags.length === 0) return;
+
+    const locationTagsIds = locationTags.map((tag)=> tag._id);
+
+    await Puzzles.updateAsync(
+      {
+        _id: puzzleId,
+      },
+      {
+        $pullAll: {
+          tags: locationTagsIds,
         },
       },
     );

--- a/imports/server/hooks/TagCleanupHooks.ts
+++ b/imports/server/hooks/TagCleanupHooks.ts
@@ -32,7 +32,6 @@ const TagCleanupHooks: Hookset = {
         },
       },
     );
-
   },
   async onNoPuzzleViewers(puzzleId: string){
     const puzzle = await Puzzles.findOneAsync(puzzleId)!;
@@ -41,7 +40,7 @@ const TagCleanupHooks: Hookset = {
 
     const tags = await Tags.find({_id: { $in: puzzle.tags } }).fetchAsync();
 
-    const locationTags = tags.filter((tag) => tag.name.startsWith("location:"));
+    const locationTags = tags.filter((tag) => tag.name.match(/^loc(ation)?:/));
 
     if( locationTags.length === 0) return;
 

--- a/imports/server/hooks/TagHooks.ts
+++ b/imports/server/hooks/TagHooks.ts
@@ -17,11 +17,9 @@ const TagHooks: Hookset = {
     const usersToNotify = new Set<string>();
     const tagName = tag.name;
 
-    console.log(`test! ${tag.name}`);
     // Respect feature flag.
     if (!(await Flags.activeAsync("disable.dingwords"))) {
       const normalizedText = tagName?.trim().toLowerCase().replace(':', ' ') ?? "";
-      console.log(normalizedText);
       // Find all users who are in this hunt with dingwords set.
       for await (const u of MeteorUsers.find(
         {
@@ -32,9 +30,7 @@ const TagHooks: Hookset = {
           fields: { _id: 1, dingwords: 1 },
         },
       )) {
-        console.log(u);
         if (normalizedMessageDingsUserByDingword(normalizedText, u)) {
-          console.log('match!')
           usersToNotify.add(u._id);
         }
       }

--- a/imports/server/hooks/TagHooks.ts
+++ b/imports/server/hooks/TagHooks.ts
@@ -1,0 +1,64 @@
+import { next } from "slate";
+import Flags from "../../Flags";
+import {
+  normalizedMessageDingsUserByDingword,
+} from "../../lib/dingwordLogic";
+import MeteorUsers from "../../lib/models/MeteorUsers";
+import PuzzleNotifications from "../../lib/models/PuzzleNotifications";
+import Puzzles from "../../lib/models/Puzzles";
+import Tags from "../../lib/models/Tags";
+import type Hookset from "./Hookset";
+
+const TagHooks: Hookset = {
+  async onAddPuzzleTag(puzzleId: string, tagId: string, addingUserId: string) {
+
+    const puzzle = Puzzles.findOne({_id: puzzleId})!;
+    const tag = Tags.findOne({_id: tagId})!;
+    const usersToNotify = new Set<string>();
+    const tagName = tag.name;
+
+    console.log(`test! ${tag.name}`);
+    // Respect feature flag.
+    if (!(await Flags.activeAsync("disable.dingwords"))) {
+      const normalizedText = tagName?.trim().toLowerCase().replace(':', ' ') ?? "";
+      console.log(normalizedText);
+      // Find all users who are in this hunt with dingwords set.
+      for await (const u of MeteorUsers.find(
+        {
+          hunts: puzzle?.hunt,
+          "dingwords.0": { $exists: true },
+        },
+        {
+          fields: { _id: 1, dingwords: 1 },
+        },
+      )) {
+        console.log(u);
+        if (normalizedMessageDingsUserByDingword(normalizedText, u)) {
+          console.log('match!')
+          usersToNotify.add(u._id);
+        }
+      }
+    }
+
+    const collected: string[] = [];
+    usersToNotify.forEach((userId) => {
+      if (userId === addingUserId) {
+        next;
+      }
+      collected.push(userId);
+    });
+    await Promise.all(
+      collected.map(async (userId: string) => {
+        await PuzzleNotifications.insertAsync({
+          user: userId,
+          puzzle: puzzleId,
+          hunt: puzzle.hunt,
+          content: `${puzzle.title} has been tagged with ${tagName}`,
+        });
+      }),
+    );
+
+  },
+};
+
+export default TagHooks;

--- a/imports/server/methods/addPuzzleTag.ts
+++ b/imports/server/methods/addPuzzleTag.ts
@@ -5,6 +5,7 @@ import Puzzles from "../../lib/models/Puzzles";
 import addPuzzleTag from "../../methods/addPuzzleTag";
 import getOrCreateTagByName from "../getOrCreateTagByName";
 import defineMethod from "./defineMethod";
+import GlobalHooks from "../GlobalHooks";
 
 defineMethod(addPuzzleTag, {
   validate(arg) {
@@ -48,5 +49,7 @@ defineMethod(addPuzzleTag, {
         },
       },
     );
+
+    await GlobalHooks.runTagAddedHooks(puzzleId, tagId, this.userId);
   },
 });

--- a/imports/server/methods/dismissPuzzleNotification.ts
+++ b/imports/server/methods/dismissPuzzleNotification.ts
@@ -1,0 +1,21 @@
+import { check } from "meteor/check";
+import PuzzleNotifications from "../../lib/models/PuzzleNotifications";
+import dismissPuzzleNotification from "../../methods/dismissPuzzleNotification";
+import defineMethod from "./defineMethod";
+
+defineMethod(dismissPuzzleNotification, {
+  validate(arg) {
+    check(arg, { puzzleNotificationId: String });
+
+    return arg;
+  },
+
+  async run({ puzzleNotificationId }) {
+    check(this.userId, String);
+
+    await PuzzleNotifications.removeAsync({
+      _id: puzzleNotificationId,
+      user: this.userId,
+    });
+  },
+});

--- a/imports/server/methods/index.ts
+++ b/imports/server/methods/index.ts
@@ -59,6 +59,7 @@ import "./rollAPIKey";
 import "./sendChatMessage";
 import "./setFeatureFlag";
 import "./setGuessState";
+import "./setUserStatus";
 import "./syncHuntDiscordRole";
 import "./undestroyHunt";
 import "./undestroyPuzzle";

--- a/imports/server/methods/index.ts
+++ b/imports/server/methods/index.ts
@@ -34,6 +34,7 @@ import "./destroyTag";
 import "./dismissBookmarkNotification";
 import "./dismissChatNotification";
 import "./dismissPendingAnnouncement";
+import "./dismissPuzzleNotification"
 import "./ensurePuzzleDocument";
 import "./fetchAPIKey";
 import "./generateUploadToken";

--- a/imports/server/methods/setUserStatus.ts
+++ b/imports/server/methods/setUserStatus.ts
@@ -1,0 +1,45 @@
+import { check, Match } from "meteor/check";
+import setUserStatus from "../../methods/setUserStatus";
+import defineMethod from "./defineMethod";
+import { serverId } from "../garbage-collection";
+import UserStatuses from "../../lib/models/UserStatuses";
+
+defineMethod(setUserStatus, {
+  validate(arg) {
+    check(arg, {
+      hunt: String,
+      type: String,
+      status: String,
+      puzzle: Match.Maybe(String),
+    });
+
+    return arg;
+  },
+
+  async run({ hunt, type, status, puzzle }) {
+    check(this.userId, String);
+
+    const user = this.userId;
+
+    let query = {
+      hunt,
+      user,
+      type,
+      server: serverId,
+      connection: this.connection?.id,
+    };
+
+    if (puzzle) {
+      query.puzzle = puzzle;
+    }
+
+    await UserStatuses.upsertAsync(
+      query,
+      {
+        $set: {
+          status: status,
+        },
+      },
+    );
+  },
+});

--- a/imports/server/publications/index.ts
+++ b/imports/server/publications/index.ts
@@ -15,6 +15,7 @@ import "./pendingAnnouncementsForSelf";
 import "./pendingGuessesForSelf";
 import "./puzzleActivityForHunt";
 import "./puzzleForPuzzlePage";
+import "./puzzleNotificationsForSelf";
 import "./puzzlesForHunt";
 import "./puzzlesForPuzzleList";
 import "./settingsAll";

--- a/imports/server/publications/index.ts
+++ b/imports/server/publications/index.ts
@@ -20,3 +20,4 @@ import "./puzzlesForHunt";
 import "./puzzlesForPuzzleList";
 import "./settingsAll";
 import "./settingsByName";
+import "./statusesForHuntUsers"

--- a/imports/server/publications/puzzleNotificationsForSelf.ts
+++ b/imports/server/publications/puzzleNotificationsForSelf.ts
@@ -1,0 +1,35 @@
+import PuzzleNotifications from "../../lib/models/PuzzleNotifications";
+import Hunts from "../../lib/models/Hunts";
+import Puzzles from "../../lib/models/Puzzles";
+import puzzleNotificationsForSelf from "../../lib/publications/puzzleNotificationsForSelf";
+import publishJoinedQuery from "../publishJoinedQuery";
+import definePublication from "./definePublication";
+
+definePublication(puzzleNotificationsForSelf, {
+  run() {
+    if (!this.userId) {
+      return [];
+    }
+
+    publishJoinedQuery(
+      this,
+      {
+        model: PuzzleNotifications,
+        foreignKeys: [
+          {
+            field: "puzzle",
+            join: { model: Puzzles },
+          },
+          {
+            field: "hunt",
+            join: { model: Hunts },
+          },
+        ],
+      },
+      { user: this.userId },
+    );
+    this.ready();
+
+    return undefined;
+  },
+});

--- a/imports/server/publications/statusesForHuntUsers.ts
+++ b/imports/server/publications/statusesForHuntUsers.ts
@@ -1,29 +1,27 @@
 import { check } from "meteor/check";
+import definePublication from "./definePublication";
+import statusesForHuntUsers from "../../lib/publications/statusesForHuntUsers";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import UserStatuses from "../../lib/models/UserStatuses";
-import statusesForHuntUsers from "../../lib/publications/statusesForHuntUsers";
-import definePublication from "./definePublication";
 
 definePublication(statusesForHuntUsers, {
   validate(arg) {
-    check(arg, {
-      huntId: String,
-    });
+    check(arg, { huntId: String });
     return arg;
   },
 
   async run({ huntId }) {
-    // if (!this.userId) {
-    //   return [];
-    // }
+    if (!this.userId) {
+      return null;
+    }
 
-    // const user = await MeteorUsers.findOneAsync(this.userId);
-    // if (!user?.hunts?.includes(huntId)) {
-    //   return [];
-    // }
-    // return UserStatuses.find({});
-    return UserStatuses.find({
-      hunt: huntId,
-    });
+    const user = await MeteorUsers.findOneAsync(this.userId);
+    if (!user?.hunts?.includes(huntId)) {
+      return [];
+    }
+
+    const recencyThreshold = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+    return [UserStatuses.find({ "hunt": huntId, updatedAt: { $gt: recencyThreshold} })];
   },
 });

--- a/imports/server/publications/statusesForHuntUsers.ts
+++ b/imports/server/publications/statusesForHuntUsers.ts
@@ -1,0 +1,29 @@
+import { check } from "meteor/check";
+import MeteorUsers from "../../lib/models/MeteorUsers";
+import UserStatuses from "../../lib/models/UserStatuses";
+import statusesForHuntUsers from "../../lib/publications/statusesForHuntUsers";
+import definePublication from "./definePublication";
+
+definePublication(statusesForHuntUsers, {
+  validate(arg) {
+    check(arg, {
+      huntId: String,
+    });
+    return arg;
+  },
+
+  async run({ huntId }) {
+    // if (!this.userId) {
+    //   return [];
+    // }
+
+    // const user = await MeteorUsers.findOneAsync(this.userId);
+    // if (!user?.hunts?.includes(huntId)) {
+    //   return [];
+    // }
+    // return UserStatuses.find({});
+    return UserStatuses.find({
+      hunt: huntId,
+    });
+  },
+});

--- a/imports/server/userStatuses.ts
+++ b/imports/server/userStatuses.ts
@@ -9,8 +9,8 @@
 import { check, Match } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import { serverId, registerPeriodicCleanupHook } from "./garbage-collection";
-import { trace } from "console";
 import UserStatuses from "../lib/models/UserStatuses";
+import { trace } from "console";
 
 // Clean up leaked subscribers from dead servers periodically.
 async function cleanupHook(deadServers: string[]) {

--- a/imports/server/userStatuses.ts
+++ b/imports/server/userStatuses.ts
@@ -1,0 +1,101 @@
+// Used to track subscribers to the subscribers.counts record set
+//
+// So long as the server continues running, it can clean up after
+// itself (and does so). But if the server process is killed (or dies
+// of more natural causes), its server record will stick around, so we
+// garbage collect subscriber records based on the updatedAt of the
+// server record.
+
+import { check, Match } from "meteor/check";
+import { Meteor } from "meteor/meteor";
+import { serverId, registerPeriodicCleanupHook } from "./garbage-collection";
+import { trace } from "console";
+import UserStatuses from "../lib/models/UserStatuses";
+
+// Clean up leaked subscribers from dead servers periodically.
+async function cleanupHook(deadServers: string[]) {
+  await UserStatuses.removeAsync({ server: { $in: deadServers } });
+}
+registerPeriodicCleanupHook(cleanupHook);
+// user status tracking
+
+Meteor.publish("userStatus.inc", async function (hunt, type, status, puzzle?) {
+  check(status, String);
+  check(hunt, String);
+  check(type, String);
+  check(puzzle, Match.Optional(String));
+
+  if (!this.userId) {
+    return [];
+  }
+
+  let selectionCriteria = {
+    server: serverId,
+    connection: this.connection.id,
+    user: this.userId,
+    type,
+    hunt,
+  }
+
+  if (puzzle){
+    selectionCriteria.puzzle = puzzle;
+  }
+
+  // Remove any existing "offline" records for this user and hunt,
+  // since we only care about them if they're not online
+  await UserStatuses.removeAsync({
+    user: this.userId,
+    type: type,
+    hunt: hunt,
+    status: "offline",
+  });
+
+  await UserStatuses.upsertAsync(selectionCriteria,
+    {
+      $set: {
+        status: status,
+      },
+    }
+  );
+
+  this.onStop(async () => {
+    // Update the status to "offline" when the subscription ends
+    await UserStatuses.updateAsync(selectionCriteria, {
+      $set: { status: "offline" }
+    });
+  });
+
+  return [];
+});
+
+Meteor.publish("userStatus.fetch", async function (huntId) {
+  check(huntId, String);
+  trace("huntId: " + huntId);
+
+  if (!this.userId) {
+    return [];
+  }
+
+  const user = await Meteor.users.findOneAsync(this.userId);
+  if (!user?.hunts?.includes(huntId)) {
+    return [];
+  }
+
+  // return UserStatuses.find({ hunt: huntId });
+
+  const cursor = UserStatuses.find({ hunt: huntId });
+  const handle = cursor.observeChanges({
+    added: (id, fields) => {
+        this.added("UserStatuses", id, { ...fields, hunt: huntId }); // Add hunt field!
+    },
+    changed: (id, fields) => {
+      this.changed("UserStatuses", id, fields);
+    },
+    removed: (id) => {
+      this.removed("UserStatuses", id);
+  },
+});
+  this.onStop(() => handle.stop());
+  this.ready();
+  return undefined;
+});

--- a/imports/server/userStatuses.ts
+++ b/imports/server/userStatuses.ts
@@ -1,16 +1,7 @@
-// Used to track subscribers to the subscribers.counts record set
-//
-// So long as the server continues running, it can clean up after
-// itself (and does so). But if the server process is killed (or dies
-// of more natural causes), its server record will stick around, so we
-// garbage collect subscriber records based on the updatedAt of the
-// server record.
-
 import { check, Match } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import { serverId, registerPeriodicCleanupHook } from "./garbage-collection";
 import UserStatuses from "../lib/models/UserStatuses";
-import { trace } from "console";
 
 // Clean up leaked subscribers from dead servers periodically.
 async function cleanupHook(deadServers: string[]) {

--- a/imports/server/userStatuses.ts
+++ b/imports/server/userStatuses.ts
@@ -67,35 +67,3 @@ Meteor.publish("userStatus.inc", async function (hunt, type, status, puzzle?) {
 
   return [];
 });
-
-Meteor.publish("userStatus.fetch", async function (huntId) {
-  check(huntId, String);
-  trace("huntId: " + huntId);
-
-  if (!this.userId) {
-    return [];
-  }
-
-  const user = await Meteor.users.findOneAsync(this.userId);
-  if (!user?.hunts?.includes(huntId)) {
-    return [];
-  }
-
-  // return UserStatuses.find({ hunt: huntId });
-
-  const cursor = UserStatuses.find({ hunt: huntId });
-  const handle = cursor.observeChanges({
-    added: (id, fields) => {
-        this.added("UserStatuses", id, { ...fields, hunt: huntId }); // Add hunt field!
-    },
-    changed: (id, fields) => {
-      this.changed("UserStatuses", id, fields);
-    },
-    removed: (id) => {
-      this.removed("UserStatuses", id);
-  },
-});
-  this.onStop(() => handle.stop());
-  this.ready();
-  return undefined;
-});

--- a/server/main.ts
+++ b/server/main.ts
@@ -35,6 +35,7 @@ import "../imports/server/server-render";
 import "../imports/server/setup";
 import "../imports/server/subscribers";
 import "../imports/server/users";
+import "../imports/server/userStatuses";
 import "../imports/server/mediasoup";
 import "../imports/server/mediasoup-api";
 


### PR DESCRIPTION
This adds a number of features to Jolly Roger:
- Last seen (and on which puzzle) on the list of users
- A bookmarklet to add a puzzle to JR, or open it if it already exists
- Users will be notified when tags match their dingwords now as well
- You can see which users are viewing each puzzle, from the list of puzzles
- `location:*` tags now have special treatment - they are ephemeral and will be removed when no one is looking at that puzzle any longer. For persistent indication that a puzzle requires presence at a specific location, consider `needs:onsite`
- We reverse the order of notifications in the list of notifications, so that you don't click on a new thing that appears and shunts your intended target up
- There is a concept of "default" roles, but we can only usefully specify operator at the moment
- 