### PR TITLE
Emojify tags in puzzle list

### DIFF
--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -85,7 +85,7 @@ const ViewControls = styled.div<{ $canAdd?: boolean }>`
 `;
 
 const SearchFormGroup = styled(FormGroup)<{ $canAdd?: boolean }>`
-  grid-column: ${(props) => (props.$canAdd ? 1 : 3)} / -1;
+  grid-column: ${(props) => (props.$canAdd ? 1 : 4)} / -1;
   ${mediaBreakpointDown(
     "sm",
     css`

--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -330,7 +330,11 @@ const Tag = (props: TagProps) => {
   const nameWithBreaks: (string | React.JSX.Element)[] = [];
   name.split(":").forEach((part, i, arr) => {
     const withColon = i < arr.length - 1;
-    nameWithBreaks.push(`${part}${withColon ? ":" : ""}`);
+    if (isMetaFor && i == 0 && !props.popoverRelated) {
+      nameWithBreaks.push(`👑 `);
+    } else {
+      nameWithBreaks.push(`${part}${withColon ? ":" : ""}`);
+    }
     if (withColon) {
       // eslint-disable-next-line react/no-array-index-key
       nameWithBreaks.push(<wbr key={`wbr-${i}-${part}`} />);


### PR DESCRIPTION
This introduces the following changes on the puzzle list page:
- Tags that are exactly `is:meta`, `is:metameta`,  `priority:high`, `priority:low`,`stuck`, and `is:stuck` are no longer displayed in the puzzle's tag list
- `is:metameta` and `is:meta` are instead rendered as a pill in their own column
- the remaining tags are rendered as emoji (with a tooltip) in their own column, in that order of precedence
- the text `meta-for:` in the taglist is instead replaced with a crown :crown:, for reasons of space conservation

There are no changes included in this to the display of tags elsewhere (intentionally, anyway)