### PR TITLE
Updates from trunk

### DIFF
--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -198,7 +198,7 @@ const PuzzleMetaColumn = styled(PuzzleColumn)`
 const PuzzlePriorityColumn = styled(PuzzleColumn)`
   padding: 0 2px;
   display: inline-block;
-  flex: 0.5;
+  flex: 1;
   margin: -2px -4px -2px 0;
   ${mediaBreakpointDown(
     "xs",
@@ -403,8 +403,10 @@ const Puzzle = React.memo(
     const isHighPriority = puzzle.tags.some(tagId => tagIndex.get(tagId)?.name === 'priority:high');
     const isLowPriority = puzzle.tags.some(tagId => tagIndex.get(tagId)?.name === 'priority:low');
     const isStuck = puzzle.tags.some(tagId => tagIndex.get(tagId)?.name === 'stuck' || tagIndex.get(tagId)?.name === 'is:stuck');
-    const statusEmoji = isHighPriority ? "🚨" : isLowPriority ? "🔽" : isStuck ? "🤷" : null;
-    const statusTooltipText = isHighPriority ? 'High priority' : isLowPriority ? 'Low priority' : isStuck ? 'Stuck' : null;
+    // const statusEmoji = isHighPriority ? "🚨" : isLowPriority ? "🔽" : isStuck ? "🤷" : null;
+    const statusEmoji = isHighPriority ? "🚨" : isLowPriority ? "🔽" : null;
+    // const statusTooltipText = isHighPriority ? 'High priority' : isLowPriority ? 'Low priority' : isStuck ? 'Stuck' : null;
+    const statusTooltipText = isHighPriority ? 'High priority' : isLowPriority ? 'Low priority' : null;
     const statusTooltip = statusEmoji ? (
       <Tooltip
       id={`puzzle-status-tooltip-${puzzleId}`}
@@ -426,7 +428,8 @@ const Puzzle = React.memo(
       emojified_tags.push('priority:high');
     } else if (isLowPriority) {
       emojified_tags.push('priority:low');
-    } else if (isStuck) {
+    }
+    if (isStuck) {
       emojified_tags.push('is:stuck', 'stuck');
     }
     const extra_suppress = allTags.filter((t) => emojified_tags.includes(t.name)).map((t) => t._id);
@@ -537,6 +540,12 @@ const Puzzle = React.memo(
                 <span>{statusEmoji}</span>
               </OverlayTrigger>
             ) : null
+          }
+          {
+            isStuck ? (<OverlayTrigger placement="top" overlay={<Tooltip id={`$stuck-tt-{puzzleId}`}>Stuck</Tooltip>}>
+              <span>🤷</span>
+            </OverlayTrigger>) : null
+
           }
         </PuzzlePriorityColumn>
         <PuzzleMetaColumn>

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -413,8 +413,23 @@ const Puzzle = React.memo(
       </Tooltip>
     ) : null;
 
-    // Now that we're putting those tags elsewhere, we're going to suppress them as welL
-    const extra_suppress = allTags.filter((t) => ['priority:low', 'priority:high', 'is:stuck', 'stuck', 'is:meta', 'is:metameta'].includes(t.name)).map((t) => t._id);
+    // Now that we're putting those tags elsewhere, we're going to suppress them as well
+    // but only the ones that are displayed
+    const emojified_tags: String[] = [];
+    if (isMetameta) {
+      emojified_tags.push('is:metameta');
+    } else if (isMeta) {
+      emojified_tags.push('is:meta');
+    }
+
+    if (isHighPriority) {
+      emojified_tags.push('priority:high');
+    } else if (isLowPriority) {
+      emojified_tags.push('priority:low');
+    } else if (isStuck) {
+      emojified_tags.push('is:stuck', 'stuck');
+    }
+    const extra_suppress = allTags.filter((t) => emojified_tags.includes(t.name)).map((t) => t._id);
 
     const shownTags = difference(puzzle.tags, suppressTags?.concat(extra_suppress) ?? []);
     const ownTags = shownTags

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -22,6 +22,7 @@ import LabelledRadioGroup from "./LabelledRadioGroup";
 import Loading from "./Loading";
 import type { ModalFormHandle } from "./ModalForm";
 import ModalForm from "./ModalForm";
+import { FormText } from "react-bootstrap";
 
 // Casting away the React.lazy because otherwise we lose access to the generic parameter
 const Creatable = React.lazy(
@@ -399,9 +400,13 @@ const PuzzleModalForm = React.forwardRef(
                 disabled={disableForm}
                 onChange={onExpectedAnswerCountChange}
                 value={currentExpectedAnswerCount}
-                min={0}
+                min={-1}
                 step={1}
               />
+              <FormText>
+                For non-puzzle items, set this to <kbd>0</kbd>.<br/>
+                For puzzles with an unknown number of answers, set this to <kbd>-1</kbd>.
+              </FormText>
             </Col>
           </FormGroup>
 

--- a/imports/lib/models/Puzzles.ts
+++ b/imports/lib/models/Puzzles.ts
@@ -22,7 +22,7 @@ const Puzzle = withCommon(
     title: nonEmptyString,
     url: z.string().url().optional(),
     answers: answer.array(),
-    expectedAnswerCount: z.number().int().nonnegative(),
+    expectedAnswerCount: z.number().int().min(-1),
     replacedBy: foreignKey.optional(),
   }),
 );

--- a/imports/lib/solvedness.ts
+++ b/imports/lib/solvedness.ts
@@ -4,7 +4,7 @@ export type Solvedness = "noAnswers" | "solved" | "unsolved";
 export const computeSolvedness = (puzzle: PuzzleType): Solvedness => {
   if (puzzle.expectedAnswerCount === 0) {
     return "noAnswers";
-  } else if (puzzle.answers.length < puzzle.expectedAnswerCount) {
+  } else if (puzzle.answers.length < puzzle.expectedAnswerCount || puzzle.expectedAnswerCount === -1) {
     return "unsolved";
   } else {
     return "solved";


### PR DESCRIPTION
This corrects the behaviour of the status/stuckness/meta columns; we now only suppress the tags that we've moved to them. For example, if a puzzle is for some reason tagged both `priority:low` and `priority:high` we will show the high priority in the column, and the `priority:low` tag in the taglist.

---

This introduces the an indeterminate number of expected puzzle answers, indicated by setting the puzzle's expected number of answers to `-1`.

Expect this to be used sparingly, as it is better to increment the expected number of answers by 1 each time we submit an answer and it is correct, but the puzzle is not treated as solved by the hunt site.

In the meantime, we will always consider such puzzles unsolved. As this means they won't get hidden from user views, such puzzles should eventually get updated with the appropriate expected number of answers.