### PR TITLE
Deduplicate new puzzles by URL, closes #24

### DIFF
--- a/imports/lib/models/Model.ts
+++ b/imports/lib/models/Model.ts
@@ -4,6 +4,7 @@ import type {
   IndexDirection,
   IndexSpecification,
   CreateIndexesOptions,
+  ClientSession,
 } from "mongodb";
 import { z } from "zod";
 import { IsInsert, IsUpdate, IsUpsert, stringId } from "./customTypes";
@@ -447,6 +448,7 @@ class Model<
     doc: z.input<this["schema"]>,
     options: {
       bypassSchema?: boolean | undefined;
+      session?: ClientSession | undefined;
     } = {},
   ): Promise<z.output<IdSchema>> {
     const { bypassSchema } = options;
@@ -456,9 +458,10 @@ class Model<
         raw = { ...doc, _id: this.collection._makeNewID() };
       }
       try {
-        await this.collection
-          .rawCollection()
-          .insertOne(raw, { bypassDocumentValidation: true });
+        await this.collection.rawCollection().insertOne(raw, {
+          bypassDocumentValidation: true,
+          session: options.session,
+        });
         return raw._id;
       } catch (e) {
         formatValidationError(e);

--- a/imports/methods/createPuzzle.ts
+++ b/imports/methods/createPuzzle.ts
@@ -9,6 +9,7 @@ export default new TypedMethod<
     tags: string[];
     expectedAnswerCount: number;
     docType: GdriveMimeTypesType;
+    allowDuplicateUrls?: boolean;
   },
   string
 >("Puzzles.methods.create");

--- a/imports/methods/updatePuzzle.ts
+++ b/imports/methods/updatePuzzle.ts
@@ -7,6 +7,7 @@ export default new TypedMethod<
     url?: string;
     tags: string[];
     expectedAnswerCount: number;
+    allowDuplicateUrls?: boolean;
   },
   void
 >("Puzzles.methods.update");

--- a/imports/server/methods/updatePuzzle.ts
+++ b/imports/server/methods/updatePuzzle.ts
@@ -22,6 +22,9 @@ defineMethod(updatePuzzle, {
       url: Match.Optional(String),
       tags: [String],
       expectedAnswerCount: Number,
+      // We accept this argument since it's provided by the form, but it's not checked here - only
+      // during puzzle creation, to avoid duplicates when creating new puzzles.
+      allowDuplicateUrls: Match.Optional(Boolean),
     });
 
     return arg;


### PR DESCRIPTION
When adding a puzzle, we start a transaction to atomically check if a puzzle already exists with that URL and only add it if either no such puzzle exists or if the client indicates that duplicate URLs are allowed. In the event of a transaction failure, we delete the Google document that was created optimistically before saving the puzzle.

On the client side, we add a new checkbox to allow duplicate URLs, unchecked by default. If we encounter a duplicate URL error, we show an error indicating that the puzzle may be a dupe and telling the user what to check if the duplicate URLs are intentional.