### PR TITLE
Jimsug/deploy action changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "14.21.3"
 
       - name: Set up environment
         run: |
@@ -35,7 +35,7 @@ jobs:
           meteor --version
 
       - name: Install dependencies
-        run: meteor npm install
+        run: meteor npm install --production
 
       - name: Build app
         run: meteor build --directory ~/${{ github.sha }} --architecture os.linux.x86_64

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,4 +64,6 @@ jobs:
             cd /home/jimsug/app
             tar -xzf jolly-roger.tar.gz
             rm jolly-roger.tar.gz
+            cd bundle/programs/server
+            MEDIASOUP_WORKER_PREBUILT_DOWNLOAD_BASE_URL="https://github.com/versatica/mediasoup/releases/download" npm install
             sudo systemctl restart jolly-roger


### PR DESCRIPTION
Updating the deploy script as per the [Meteor docs](https://guide.meteor.com/deployment.html#custom-deployment):

- Only install production dependencies
- Also install server dependencies after untarring

(NB: because I run JR with a `.service` file, there is no need to be in the bundle directory to restart it.)