### PR TITLE
Introduce a way to purge hunt content

### DIFF
--- a/imports/methods/purgeHunt.ts
+++ b/imports/methods/purgeHunt.ts
@@ -1,0 +1,3 @@
+import TypedMethod from "./TypedMethod";
+
+export default new TypedMethod<{ huntId: string }, void>("Hunts.methods.purge");

--- a/imports/server/methods/index.ts
+++ b/imports/server/methods/index.ts
@@ -34,7 +34,7 @@ import "./destroyTag";
 import "./dismissBookmarkNotification";
 import "./dismissChatNotification";
 import "./dismissPendingAnnouncement";
-import "./dismissPuzzleNotification"
+import "./dismissPuzzleNotification";
 import "./ensurePuzzleDocument";
 import "./fetchAPIKey";
 import "./generateUploadToken";
@@ -52,6 +52,7 @@ import "./mediasoupSetProducerPaused";
 import "./postAnnouncement";
 import "./promoteOperator";
 import "./provisionFirstUser";
+import "./purgeHunt";
 import "./removePuzzleAnswer";
 import "./removePuzzleTag";
 import "./renameTag";

--- a/imports/server/methods/purgeHunt.ts
+++ b/imports/server/methods/purgeHunt.ts
@@ -1,0 +1,48 @@
+import { check } from "meteor/check";
+import Announcements from "../../lib/models/Announcements";
+import Bookmarks from "../../lib/models/Bookmarks";
+import ChatMessages from "../../lib/models/ChatMessages";
+import ChatNotifications from "../../lib/models/ChatNotifications";
+import DocumentActivities from "../../lib/models/DocumentActivities";
+import Documents from "../../lib/models/Documents";
+import Guesses from "../../lib/models/Guesses";
+import MeteorUsers from "../../lib/models/MeteorUsers";
+import PendingAnnouncements from "../../lib/models/PendingAnnouncements";
+import PuzzleNotifications from "../../lib/models/PuzzleNotifications";
+import Puzzles from "../../lib/models/Puzzles";
+import CallHistories from "../../lib/models/mediasoup/CallHistories";
+import Rooms from "../../lib/models/mediasoup/Rooms";
+import { checkAdmin } from "../../lib/permission_stubs";
+import purgeHunt from "../../methods/purgeHunt";
+import CallActivities from "../models/CallActivities";
+import Subscribers from "../models/Subscribers";
+import defineMethod from "./defineMethod";
+
+defineMethod(purgeHunt, {
+  validate(arg) {
+    check(arg, { huntId: String });
+    return arg;
+  },
+
+  async run({ huntId }) {
+    check(this.userId, String);
+    checkAdmin(await MeteorUsers.findOneAsync(this.userId));
+
+    const hunt = huntId;
+
+    await Puzzles.removeAsync({ hunt });
+    await Documents.removeAsync({ hunt });
+    await ChatMessages.removeAsync({ hunt });
+    await Announcements.removeAsync({ hunt });
+    await Bookmarks.removeAsync({ hunt });
+    await CallActivities.removeAsync({ hunt });
+    await ChatNotifications.removeAsync({ hunt });
+    await DocumentActivities.removeAsync({ hunt });
+    await Guesses.removeAsync({ hunt });
+    await CallHistories.removeAsync({ hunt });
+    await Rooms.removeAsync({ hunt });
+    await PendingAnnouncements.removeAsync({ hunt });
+    await PuzzleNotifications.removeAsync({ hunt });
+    await Subscribers.removeAsync({ hunt });
+  },
+});


### PR DESCRIPTION
@santheo This introduces a way to purge hunt content in the UI, as we've discussed.

I think it destroys most or all of the items we care about. There might just need to be some care taken around people on calls - not sure what happens if we destroy a call while someone is active on it, but I'm sure nothing world-ending.