### PR TITLE
Re-enable and protect purge hunt

### DIFF
--- a/imports/client/components/Routes.tsx
+++ b/imports/client/components/Routes.tsx
@@ -20,6 +20,7 @@ import HuntersApp from "./HuntersApp";
 import HuntListApp from "./HuntListApp";
 import HuntListPage from "./HuntListPage";
 import HuntProfileListPage from "./HuntProfileListPage";
+import HuntPurgePage from "./HuntPurgePage";
 import JoinHunt from "./JoinHunt";
 import Loading from "./Loading";
 import LoginForm from "./LoginForm";
@@ -66,6 +67,7 @@ export const AuthenticatedRouteList: RouteObject[] = [
           { path: "more", element: <MoreAppPage /> },
           { path: "tags", element: <TagBulkEditPage /> },
           { path: "notes", element: <NotesPage /> },
+          { path: "purge", element: <HuntPurgePage /> },
           { path: "", element: <Navigate to="puzzles" replace /> },
         ],
       },


### PR DESCRIPTION
This re-adds a route to purge the hunt. It's now guarded by checkAdmin, which will redirect the user to /puzzles for the hunt if they are not a global admin.

This will close #145 