### PR TITLE
Allow guesses to be edited when marked correct

### DIFF
--- a/imports/methods/setGuessState.ts
+++ b/imports/methods/setGuessState.ts
@@ -6,6 +6,7 @@ export default new TypedMethod<
     guessId: string;
     state: GuessType["state"];
     additionalNotes?: string;
+    correctAnswer?: string;
   },
   void
 >("Guesses.methods.setState");

--- a/imports/server/methods/setGuessState.ts
+++ b/imports/server/methods/setGuessState.ts
@@ -1,5 +1,5 @@
 import { check, Match } from "meteor/check";
-import { Meteor } from "meteor/meteor";
+import { Meteor } from "meteor/meteor";\
 import Logger from "../../Logger";
 import Guesses, { GuessStates } from "../../lib/models/Guesses";
 import Hunts from "../../lib/models/Hunts";
@@ -16,11 +16,12 @@ defineMethod(setGuessState, {
       guessId: String,
       state: Match.OneOf(...GuessStates.options),
       additionalNotes: Match.Optional(String),
+      correctAnswer: Match.Optional(String),
     });
     return arg;
   },
 
-  async run({ guessId, state, additionalNotes }) {
+  async run({ guessId, state, additionalNotes, correctAnswer }) {
     check(this.userId, String);
 
     const guess = await Guesses.findOneAsync(guessId);
@@ -46,7 +47,13 @@ defineMethod(setGuessState, {
       guess: guess._id,
       state,
       additionalNotes,
+      correctAnswer,
     });
-    await transitionGuess(guess, state, additionalNotes);
+    await transitionGuess(
+      guess,
+      state,
+      additionalNotes,
+      correctAnswer,
+    );
   },
 });


### PR DESCRIPTION
From time to time, we will submit an answer that is correct but for the spacing. This change allows users who are actioning guesses to respace the answer (and actually edit it completely if desired), so that we don't need to do a "reject and resubmit" dance.

The guess notification now displays a split button for correct answers, and most of the time users should just select the main "Correct" button. When they have an answer that is correct but needs to be respaced, they can click the split button, and the "Correct with edit..."  button.

Then, they can enter the correct answer. If they make changes other than respacing, we will display a message and request that they confirm again. Users will be able to completely edit an answer if they wish.

This addresses #600