### PR TITLE
Add special styling for puzzles that appear in multiple places

### DIFF
--- a/imports/client/components/PuzzleList.tsx
+++ b/imports/client/components/PuzzleList.tsx
@@ -1,12 +1,46 @@
-import React from "react";
-import styled from "styled-components";
+import React, { useContext } from "react";
+import styled, { css } from "styled-components";
 import type { ChatMessageType } from "../../lib/models/ChatMessages";
 import type { PuzzleType } from "../../lib/models/Puzzles";
 import type { TagType } from "../../lib/models/Tags";
 import Puzzle from "./Puzzle";
+import { PuzzleHoverContext } from "./PuzzleListPage";
 
 const StyledPuzzleListDiv = styled.div`
   margin-bottom: 1em;
+`;
+
+const PuzzleWrapper = styled.div<{ $isHovered: boolean; $isMulti: boolean }>`
+  transition:
+    background-color 0.1s ease-in-out,
+    box-shadow 0.1s ease-in-out,
+    transform 0.1s ease-in-out;
+  border-radius: 4px;
+  border: 1px solid transparent; /* Reserve space for border */
+
+  ${(props) =>
+    props.$isHovered &&
+    !props.$isMulti &&
+    css`
+      /* Standard Highlight for single items */
+      background-color: ${({ theme }) => theme.colors.autocompleteBackground};
+      box-shadow: 0 2px 4px ${({ theme }) => theme.colors.autocompleteShadow};
+      border-color: ${({ theme }) => theme.colors.autocompleteShadow};
+      position: relative;
+      z-index: 1;
+    `}
+
+  ${(props) =>
+    props.$isHovered &&
+    props.$isMulti &&
+    css`
+      /* "Linked" Highlight for items appearing multiple times */
+      background-color: ${({ theme }) => theme.colors.autocompleteBackground};
+      box-shadow: 0 0 0 1px ${({ theme }) => theme.colors.info}, 0 2px 8px ${({ theme }) => theme.colors.info};
+      border-color: ${({ theme }) => theme.colors.info};
+      position: relative;
+      z-index: 2; /* Sit higher than single items */
+    `}
 `;
 
 const PuzzleList = React.memo(
@@ -22,10 +56,8 @@ const PuzzleList = React.memo(
     pinnedMessages,
     puzzleUsers,
   }: {
-    // The puzzles to show in this list
     puzzles: PuzzleType[];
     bookmarked: Set<string>;
-    // All tags for this hunt, including those not used by any puzzles
     allTags: TagType[];
     canUpdate: boolean;
     showSolvers: "viewers" | "hide" | "active";
@@ -35,34 +67,45 @@ const PuzzleList = React.memo(
     pinnedMessages?: ChatMessageType[] | null;
     puzzleUsers: Record<string, string[]>;
   }) => {
-    // This component just renders the puzzles provided, in order.
-    // Adjusting order based on tags, tag groups, etc. is to be done at
-    // a higher layer.
+    // Consume the expanded context
+    const { hoveredPuzzleId, setHoveredPuzzleId, multiOccurrenceIds } =
+      useContext(PuzzleHoverContext);
+
     return (
       <StyledPuzzleListDiv className="puzzle-list">
         {puzzles.map((puzzle) => {
           const puzzleId = puzzle._id;
+          const isHovered = hoveredPuzzleId === puzzleId;
+          const isMulti = multiOccurrenceIds.has(puzzleId);
+
           return (
-            <Puzzle
-              key={puzzle._id}
-              puzzle={puzzle}
-              bookmarked={bookmarked.has(puzzle._id)}
-              allTags={allTags}
-              canUpdate={canUpdate}
-              suppressTags={suppressTags}
-              segmentAnswers={segmentAnswers}
-              showSolvers={showSolvers}
-              subscribers={
-                subscribers && puzzleId in subscribers
-                  ? subscribers[puzzleId]
-                  : null
-              }
-              puzzleUsers={
-                puzzleUsers && puzzleId in puzzleUsers
-                  ? puzzleUsers[puzzleId]
-                  : []
-              }
-            />
+            <PuzzleWrapper
+              key={puzzleId}
+              $isHovered={isHovered}
+              $isMulti={isMulti}
+              onMouseEnter={() => setHoveredPuzzleId(puzzleId)}
+              onMouseLeave={() => setHoveredPuzzleId(null)}
+            >
+              <Puzzle
+                puzzle={puzzle}
+                bookmarked={bookmarked.has(puzzleId)}
+                allTags={allTags}
+                canUpdate={canUpdate}
+                suppressTags={suppressTags}
+                segmentAnswers={segmentAnswers}
+                showSolvers={showSolvers}
+                subscribers={
+                  subscribers && puzzleId in subscribers
+                    ? subscribers[puzzleId]
+                    : null
+                }
+                puzzleUsers={
+                  puzzleUsers && puzzleId in puzzleUsers
+                    ? puzzleUsers[puzzleId]
+                    : []
+                }
+              />
+            </PuzzleWrapper>
           );
         })}
       </StyledPuzzleListDiv>


### PR DESCRIPTION
Add a subtle shadow effect to puzzles on hover, but add a glow if a puzzle is in more than one group and it's hovered, as a cue that there's something the user should pay attention to