### PR TITLE
Allow users to indicate whether they are offsite or not

### DIFF
--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -6,6 +6,7 @@ import { useCallback, useId, useMemo, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Container from "react-bootstrap/Container";
+import FormCheck from "react-bootstrap/FormCheck";
 import type { FormControlProps } from "react-bootstrap/FormControl";
 import FormControl from "react-bootstrap/FormControl";
 import FormGroup from "react-bootstrap/FormGroup";
@@ -227,6 +228,9 @@ const OwnProfilePage = ({
   const [dingwordsOpenMatch, setDingwordsOpenMatch] = useState<boolean>(
     initialUser.dingwordsOpenMatch ?? false,
   );
+  const [isOffsite, setIsOffsite] = useState<boolean>(
+    initialUser.isOffsite ?? false,
+  );
   const [submitState, setSubmitState] = useState<OwnProfilePageSubmitState>(
     OwnProfilePageSubmitState.IDLE,
   );
@@ -253,6 +257,13 @@ const OwnProfilePage = ({
     setDingwordsOpenMatch(newMode === "open");
   }, []);
 
+  const handleIsOffsiteChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setIsOffsite(e.currentTarget.checked);
+    },
+    [],
+  );
+
   const handleSaveForm = useCallback(() => {
     const trimmedDisplayName = displayName.trim();
     if (trimmedDisplayName === "") {
@@ -273,6 +284,7 @@ const OwnProfilePage = ({
       phoneNumber: phoneNumber !== "" ? phoneNumber : undefined,
       dingwords,
       dingwordsOpenMatch,
+      isOffsite,
     };
     updateProfile.call(newProfile, (error) => {
       if (error) {
@@ -282,7 +294,7 @@ const OwnProfilePage = ({
         setSubmitState(OwnProfilePageSubmitState.SUCCESS);
       }
     });
-  }, [dingwordsFlat, dingwordsOpenMatch, displayName, phoneNumber]);
+  }, [dingwordsFlat, dingwordsOpenMatch, displayName, phoneNumber, isOffsite]);
 
   const dismissAlert = useCallback(() => {
     setSubmitState(OwnProfilePageSubmitState.IDLE);
@@ -333,9 +345,7 @@ const OwnProfilePage = ({
       </FormGroup>
 
       <FormGroup className="mb-3" controlId={`${idPrefix}-dingwords`}>
-        <FormLabel htmlFor="jr-profile-edit-dingwords">
-          Dingwords (comma-separated)
-        </FormLabel>
+        <FormLabel>Dingwords (comma-separated)</FormLabel>
         <FormControl
           type="text"
           value={dingwordsFlat}
@@ -351,9 +361,7 @@ const OwnProfilePage = ({
       </FormGroup>
 
       <FormGroup className="mb-3" controlId={`${idPrefix}-dingwords-open`}>
-        <FormLabel htmlFor={`${idPrefix}-dingwords-open`}>
-          Dingwords matching mode
-        </FormLabel>
+        <FormLabel>Dingwords matching mode</FormLabel>
         <LabelledRadioGroup
           header=""
           name={`${idPrefix}-dingwords-open`}
@@ -384,6 +392,14 @@ const OwnProfilePage = ({
           initialValue={dingwordsOpenMatch ? "open" : "exact"}
           help=""
           onChange={handleDingwordsModeChange}
+        />
+      </FormGroup>
+      <FormGroup className="mb-3" controlId={`${idPrefix}-is-offsite`}>
+        <FormLabel>Are you hunting remotely?</FormLabel>
+        <FormCheck
+          checked={isOffsite}
+          onChange={handleIsOffsiteChange}
+          label="I'm hunting remotely"
         />
       </FormGroup>
       {submitState === "submitting" ? (

--- a/imports/client/components/RelatedPuzzleList.tsx
+++ b/imports/client/components/RelatedPuzzleList.tsx
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor";
+import { useTracker } from "meteor/react-meteor-data";
 import React from "react";
 import { indexedById } from "../../lib/listUtils";
 import type { PuzzleType } from "../../lib/models/Puzzles";
@@ -29,6 +31,7 @@ const RelatedPuzzleList = React.memo(
     subscribers: Record<string, Record<string, string[]>>;
     puzzleUsers: Record<string, string[]>;
   }) => {
+    const isOffsite = useTracker(() => Meteor.user()?.isOffsite ?? false, []);
     // Sort the puzzles within each tag group by interestingness.  For instance, metas
     // should probably be at the top of the group, then of the round puzzles, unsolved should
     // maybe sort above solved, and then perhaps by unlock order.
@@ -37,6 +40,7 @@ const RelatedPuzzleList = React.memo(
       relatedPuzzles,
       sharedTag,
       tagIndex,
+      isOffsite,
     );
     return (
       <PuzzleList

--- a/imports/client/components/TagList.tsx
+++ b/imports/client/components/TagList.tsx
@@ -67,7 +67,10 @@ const soloTagInterestingness = (tag: TagType) => {
     return -3;
   } else if (tag.name.lastIndexOf("needs:", 0) === 0) {
     return -2;
-  } else if (tag.name.lastIndexOf("priority:", 0) === 0) {
+  } else if (
+    tag.name.lastIndexOf("priority:", 0) === 0 ||
+    tag.name.lastIndexOf("where:", 0) === 0
+  ) {
     return -1;
   } else {
     return 0;

--- a/imports/lib/models/User.ts
+++ b/imports/lib/models/User.ts
@@ -63,6 +63,7 @@ export const User = z.object({
   suppressedDingwords: z
     .record(z.string(), z.record(z.string(), nonEmptyString.array()))
     .optional(),
+  isOffsite: z.boolean().optional(),
 });
 validateSchema(User);
 
@@ -74,6 +75,7 @@ export type ProfileFields =
   | "hunts"
   | "dingwords"
   | "dingwordsOpenMatch"
-  | "suppressedDingwords";
+  | "suppressedDingwords"
+  | "isOffsite";
 
 export default User;

--- a/imports/lib/puzzle-sort-and-group.ts
+++ b/imports/lib/puzzle-sort-and-group.ts
@@ -23,6 +23,7 @@ function puzzleInterestingness(
   puzzle: PuzzleType,
   indexedTags: Map<string, TagType>,
   group: string | undefined,
+  isOffsite?: boolean,
 ): number {
   // If the shared tag for this group is group:<something>, then group will equal '<something>', and
   // we wish to sort a puzzle named 'meta-for:<something>' at the top.
@@ -33,6 +34,20 @@ function puzzleInterestingness(
   let isAdministrivia = false;
   let isGroup = false;
   let minScore = 0;
+
+  puzzle.tags.forEach((tagId) => {
+    const tag = indexedTags.get(tagId);
+    if (tag) {
+      if (
+        isOffsite &&
+        (tag.name === "where:campus" || tag.name === "where:mit")
+      ) {
+        minScore = Math.max(2, minScore);
+      } else if (tag.name === "priority:low") {
+        minScore = Math.max(1, minScore);
+      }
+    }
+  });
 
   puzzle.tags.forEach((tagId) => {
     const tag = indexedTags.get(tagId);
@@ -397,6 +412,7 @@ function sortPuzzlesByRelevanceWithinPuzzleGroup(
   puzzles: PuzzleType[],
   sharedTag: TagType | undefined,
   indexedTags: Map<string, TagType>,
+  isOffsite?: boolean,
 ) {
   let group: string | undefined;
   if (sharedTag && sharedTag.name.lastIndexOf("group:", 0) === 0) {
@@ -404,8 +420,8 @@ function sortPuzzlesByRelevanceWithinPuzzleGroup(
   }
   const sortedPuzzles = puzzles.slice(0);
   sortedPuzzles.sort((a, b) => {
-    const ia = puzzleInterestingness(a, indexedTags, group);
-    const ib = puzzleInterestingness(b, indexedTags, group);
+    const ia = puzzleInterestingness(a, indexedTags, group, isOffsite ?? false);
+    const ib = puzzleInterestingness(b, indexedTags, group, isOffsite ?? false);
     if (ia !== ib) {
       return ia - ib;
     } else {

--- a/imports/methods/updateProfile.ts
+++ b/imports/methods/updateProfile.ts
@@ -6,6 +6,7 @@ export default new TypedMethod<
     phoneNumber?: string;
     dingwords: string;
     dingwordsOpenMatch?: boolean;
+    isOffsite?: boolean;
   },
   void
 >("Users.methods.updateProfile");

--- a/imports/server/methods/updateProfile.ts
+++ b/imports/server/methods/updateProfile.ts
@@ -12,12 +12,19 @@ defineMethod(updateProfile, {
       phoneNumber: Match.Optional(String),
       dingwords: [String],
       dingwordsOpenMatch: Match.Optional(Boolean),
+      isOffsite: Match.Optional(Boolean),
     });
 
     return arg;
   },
 
-  async run({ displayName, phoneNumber, dingwords, dingwordsOpenMatch }) {
+  async run({
+    displayName,
+    phoneNumber,
+    dingwords,
+    dingwordsOpenMatch,
+    isOffsite,
+  }) {
     // Allow users to update/upsert profile data.
     check(this.userId, String);
 
@@ -41,6 +48,7 @@ defineMethod(updateProfile, {
           phoneNumber,
           dingwords,
           dingwordsOpenMatch,
+          isOffsite,
         },
         $unset: unset,
       },

--- a/imports/server/users.ts
+++ b/imports/server/users.ts
@@ -21,6 +21,7 @@ const profileFields: Record<ProfileFields, 1> = {
   dingwords: 1,
   dingwordsOpenMatch: 1,
   suppressedDingwords: 1,
+  isOffsite: 1,
 };
 
 // This overrides the default set of fields that are published to the


### PR DESCRIPTION
... and also hoist "where:" tags up the list of tags

When a user indicates that they are offsite, we sort puzzles below low-priority puzzles, which we also now put below other puzzles.

The exception to this is when a puzzle is hoisted up the group for some other reason - when it's a meta, or high priority, for instance.