### PR TITLE
A probably more future-proof fix

### DIFF
--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -1070,7 +1070,7 @@ const NotificationCenter = () => {
   useSubscribe(
     activeOperatorHunts.length > 0 ? "subscribers.inc" : undefined,
     "operators",
-    Object.fromEntries(activeOperatorHunts.map((h) => [h, "true"])),
+    Object.fromEntries(activeOperatorHunts.map((h) => [h, true])),
   );
 
   const pendingAnnouncementsLoading = useTypedSubscribe(

--- a/imports/server/subscribers.ts
+++ b/imports/server/subscribers.ts
@@ -24,7 +24,9 @@ const contextMatcher = Match.Where(
       return false;
     }
 
-    return Object.values(val).every((v) => Match.test(v, String));
+    return Object.values(val).every(
+      (v) => Match.test(v, String) || Match.test(v, Boolean),
+    );
   },
 );
 


### PR DESCRIPTION
... since changes upstream may make use of booleans in subscriptions